### PR TITLE
Add reporting_mandate signal phrases to config/checks.yaml

### DIFF
--- a/config/checks.yaml
+++ b/config/checks.yaml
@@ -11,3 +11,17 @@ checks:
     phrases:
       - "co-facilitators"
       - "co-chairs"
+
+  - signal: "reporting_mandate"
+    phrases:
+      - "report to the General Assembly"
+      - "submit a report"
+      - "report thereon"
+      - "shall report"
+      - "apprise the General Assembly"
+      - "inform the General Assembly"
+      - "include in his report"
+      - "include in the report"
+      - "Secretary-General to submit"
+      - "Secretary-General to report"
+      - "Secretary-General to provide a report"


### PR DESCRIPTION
### Motivation
- Add phrase patterns to detect reporting mandates (including explicit instructions to the Secretary-General) in the checks configuration.

### Description
- Added a `reporting_mandate` signal to `config/checks.yaml` with phrases such as "report to the General Assembly", "submit a report", "report thereon", "shall report", "apprise the General Assembly", "inform the General Assembly", "include in his report", "include in the report", "Secretary-General to submit", "Secretary-General to report", and "Secretary-General to provide a report".

### Testing
- No automated tests were run for this config-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970e11fefdc832eaf1ea703f6748d9a)