### PR TITLE
Remove landing page totals from signal matrix

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -97,8 +97,7 @@
                         </a>
                     </th>
                     
-                    <th class="text-center py-3 px-4 text-sm font-medium text-gray-500 bg-gray-50 rounded-tr-lg">Total</th>
-                </tr>
+                                    </tr>
             </thead>
             <tbody class="divide-y divide-gray-100">
                 
@@ -159,10 +158,6 @@
                         </a>
                         
                     </td>
-                    
-                    <td class="text-center py-4 px-4">
-                        <span class="text-sm font-semibold text-gray-900">243</span>
-                    </td>
                 </tr>
                 
                 
@@ -221,10 +216,6 @@
                             13
                         </a>
                         
-                    </td>
-                    
-                    <td class="text-center py-4 px-4">
-                        <span class="text-sm font-semibold text-gray-900">42</span>
                     </td>
                 </tr>
                 
@@ -285,10 +276,6 @@
                         </a>
                         
                     </td>
-                    
-                    <td class="text-center py-4 px-4">
-                        <span class="text-sm font-semibold text-gray-900">63</span>
-                    </td>
                 </tr>
                 
                 
@@ -347,10 +334,6 @@
                             59
                         </a>
                         
-                    </td>
-                    
-                    <td class="text-center py-4 px-4">
-                        <span class="text-sm font-semibold text-gray-900">63</span>
                     </td>
                 </tr>
                 
@@ -411,10 +394,6 @@
                         </a>
                         
                     </td>
-                    
-                    <td class="text-center py-4 px-4">
-                        <span class="text-sm font-semibold text-gray-900">65</span>
-                    </td>
                 </tr>
                 
                 
@@ -473,10 +452,6 @@
                             14
                         </a>
                         
-                    </td>
-                    
-                    <td class="text-center py-4 px-4">
-                        <span class="text-sm font-semibold text-gray-900">21</span>
                     </td>
                 </tr>
                 
@@ -537,10 +512,6 @@
                         </a>
                         
                     </td>
-                    
-                    <td class="text-center py-4 px-4">
-                        <span class="text-sm font-semibold text-gray-900">22</span>
-                    </td>
                 </tr>
                 
                 
@@ -600,36 +571,9 @@
                         </a>
                         
                     </td>
-                    
-                    <td class="text-center py-4 px-4">
-                        <span class="text-sm font-semibold text-gray-900">24</span>
-                    </td>
                 </tr>
                 
             </tbody>
-            <tfoot>
-                <tr class="bg-gray-50">
-                    <td class="py-3 px-4 text-sm font-semibold text-gray-700 rounded-bl-lg">Total</td>
-                    
-                    <td class="text-center py-3 px-4">
-                        <span class="text-sm font-semibold text-gray-700">285</span>
-                    </td>
-                    
-                    <td class="text-center py-3 px-4">
-                        <span class="text-sm font-semibold text-gray-700">1296</span>
-                    </td>
-                    
-                    <td class="text-center py-3 px-4">
-                        <span class="text-sm font-semibold text-gray-700">101</span>
-                    </td>
-                    
-                    <td class="text-center py-3 px-4">
-                        <span class="text-sm font-semibold text-gray-700">427</span>
-                    </td>
-                    
-                    <td class="text-center py-3 px-4 text-sm font-bold text-gray-900 rounded-br-lg">543</td>
-                </tr>
-            </tfoot>
         </table>
     </div>
 </div>

--- a/src/mandate_pipeline/templates/static/index.html
+++ b/src/mandate_pipeline/templates/static/index.html
@@ -29,7 +29,6 @@
                         </a>
                     </th>
                     {% endfor %}
-                    <th class="text-center py-3 px-4 text-sm font-medium text-gray-500 bg-gray-50 rounded-tr-lg">Total</th>
                 </tr>
             </thead>
             <tbody class="divide-y divide-gray-100">
@@ -58,23 +57,9 @@
                         {% endif %}
                     </td>
                     {% endfor %}
-                    <td class="text-center py-4 px-4">
-                        <span class="text-sm font-semibold text-gray-900">{{ pattern_doc_counts.get(pattern.name, 0) }}</span>
-                    </td>
                 </tr>
                 {% endfor %}
             </tbody>
-            <tfoot>
-                <tr class="bg-gray-50">
-                    <td class="py-3 px-4 text-sm font-semibold text-gray-700 rounded-bl-lg">Total</td>
-                    {% for check in checks %}
-                    <td class="text-center py-3 px-4">
-                        <span class="text-sm font-semibold text-gray-700">{{ total_signal_counts.get(check.signal, 0) }}</span>
-                    </td>
-                    {% endfor %}
-                    <td class="text-center py-3 px-4 text-sm font-bold text-gray-900 rounded-br-lg">{{ total_docs }}</td>
-                </tr>
-            </tfoot>
         </table>
     </div>
 </div>


### PR DESCRIPTION
### Motivation

- The landing-page signal matrix displayed row and column totals that are not meaningful and clutter the matrix, so they were removed to simplify the UI.

### Description

- Remove the `Total` column header, per-row total cell, and footer totals from the landing-page template in `src/mandate_pipeline/templates/static/index.html`.
- Sync the generated landing page HTML `docs/index.html` to match the updated template by removing the corresponding total cells and the `<tfoot>` totals block.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f407eddc832e8e5697d9cd338311)