### PR TITLE
Expand amendment target scan window and detect revisioned draft symbols

### DIFF
--- a/src/mandate_pipeline/static_generator.py
+++ b/src/mandate_pipeline/static_generator.py
@@ -56,6 +56,24 @@ def filename_to_symbol(filename: str) -> str:
     return symbol
 
 
+def classify_doc_type(symbol: str, text: str) -> str:
+    """Classify the document type based on symbol and first-page cues."""
+    # Heuristic trade-offs:
+    # - Symbol prefix is authoritative for resolutions, but amendments are only
+    #   inferred from front-matter text that can vary by language/layout.
+    # - We bias toward "proposal" when the signal is ambiguous to avoid
+    #   over-labeling non-amendments.
+    if symbol.startswith("A/RES/"):
+        return "resolution"
+
+    first_page = text.split("\f", 1)[0]
+    title_window = first_page[:2000]
+    if re.search(r"\bAmendment\b", title_window, re.IGNORECASE):
+        return "amendment"
+
+    return "proposal"
+
+
 def load_all_documents(data_dir: Path, checks: list) -> list[dict]:
     """
     Load all documents from the data directory.
@@ -84,6 +102,25 @@ def load_all_documents(data_dir: Path, checks: list) -> list[dict]:
             text = extract_text(pdf_file)
             paragraphs = extract_operative_paragraphs(text)
 
+            doc_type = classify_doc_type(symbol, text)
+            # Heuristic trade-offs:
+            # - We scan a short front-matter window to keep it fast, but
+            #   amendments can reference targets later in the document.
+            # - The regex is conservative, so unknown formats fall back to None.
+            # - We now capture optional /Rev.X suffixes found in draft symbols.
+            base_proposal_symbol = None
+            if doc_type == "proposal":
+                base_proposal_symbol = symbol
+            elif doc_type == "amendment":
+                front_matter = text.split("\f", 2)[0:2]
+                front_matter_text = "\f".join(front_matter)[:4000]
+                symbol_match = re.search(
+                    r"\bA/\d+/(?:L\.\d+|C\.\d+/\d+/L\.\d+|C\.\d+/L\.\d+)(?:/Rev\.\d+)?\b",
+                    front_matter_text
+                )
+                if symbol_match:
+                    base_proposal_symbol = symbol_match.group(0)
+
             # Run checks
             signals = run_checks(paragraphs, checks) if checks else {}
 
@@ -96,6 +133,8 @@ def load_all_documents(data_dir: Path, checks: list) -> list[dict]:
             documents.append({
                 "symbol": symbol,
                 "filename": pdf_file.name,
+                "doc_type": doc_type,
+                "base_proposal_symbol": base_proposal_symbol,
                 "paragraphs": paragraphs,
                 "signals": signals,
                 "signal_summary": signal_summary,


### PR DESCRIPTION
### Motivation
- Amendments sometimes reference their target draft symbols in front-matter that appears beyond the first page, and some draft symbols include `/Rev.X` suffixes which were not being matched. 
- The change aims to improve detection of amendment targets without scanning entire PDFs to keep performance reasonable.

### Description
- Add a `classify_doc_type(symbol, text)` heuristic to infer `doc_type` (proposal/amendment/resolution) from the symbol and front-matter cues. 
- For amendments, expand the scan window to the first two pages (joined and capped at 4,000 characters) when searching for target symbols and keep the regex conservative. 
- Extend the amendment-target regex to accept optional revision suffixes using `(?:/Rev\.\d+)?` and store `doc_type` and `base_proposal_symbol` in the document metadata. 
- Keep updated heuristic notes inline and return the augmented document dicts from `load_all_documents` (all changes in `src/mandate_pipeline/static_generator.py`).

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f680733c832e8be74aed8515a68f)