### PR TITLE
chore: add lineage cache and CLI command; gate workflows on PDF and lineage changes

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -7,7 +7,7 @@ on:
     branches:
       - main
     paths:
-      - 'data/**'
+      - 'data/lineage.json'
       - 'config/**'
       - 'src/**'
       - '.github/workflows/build-site.yml'

--- a/.github/workflows/linkage-analysis.yml
+++ b/.github/workflows/linkage-analysis.yml
@@ -1,0 +1,85 @@
+name: Linkage Analysis
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - 'data/pdfs/**'
+  workflow_run:
+    workflows:
+      - Fetch Documents
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+concurrency:
+  group: "lineage-analysis"
+  cancel-in-progress: false
+
+jobs:
+  analyze:
+    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Check for PDF changes
+        id: pdf_changes
+        run: |
+          if git rev-parse HEAD~1 >/dev/null 2>&1; then
+            if git diff --name-only HEAD~1..HEAD | rg '^data/pdfs/'; then
+              echo "has_changes=true" >> $GITHUB_OUTPUT
+            else
+              echo "has_changes=false" >> $GITHUB_OUTPUT
+            fi
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Python
+        if: steps.pdf_changes.outputs.has_changes == 'true'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: 'pip'
+
+      - name: Install dependencies
+        if: steps.pdf_changes.outputs.has_changes == 'true'
+        run: |
+          pip install -e .
+
+      - name: Run linkage analysis
+        if: steps.pdf_changes.outputs.has_changes == 'true'
+        run: |
+          python -m mandate_pipeline.cli lineage --verbose --config ./config --data ./data --output ./docs
+
+      - name: Check for changes
+        if: steps.pdf_changes.outputs.has_changes == 'true'
+        id: changes
+        run: |
+          git add data/lineage.json docs/data.json
+          echo "::group::Changes Summary"
+          git diff --staged --stat || echo "No changes"
+          echo "::endgroup::"
+          
+          if git diff --staged --quiet; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "::notice::No changes to commit"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "::notice::Changes detected, will commit"
+          fi
+
+      - name: Commit changes
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "chore: update lineage cache $(date -I)"
+          git pull --rebase origin main || true
+          git push

--- a/data/lineage.json
+++ b/data/lineage.json
@@ -1,0 +1,4 @@
+{
+  "generated_at": null,
+  "documents": {}
+}

--- a/src/mandate_pipeline/cli.py
+++ b/src/mandate_pipeline/cli.py
@@ -1,15 +1,15 @@
 """Command-line interface for Mandate Pipeline."""
 
 import argparse
-import json
 import os
 import sys
 import time
 from pathlib import Path
 
-from .pipeline import sync_all_patterns_verbose, load_patterns, load_sync_state
-from .static_generator import generate_site_verbose
+from .pipeline import sync_all_patterns_verbose, load_sync_state
+from .static_generator import generate_site_verbose, load_all_documents, generate_data_json
 from .checks import load_checks
+from .lineage import update_lineage_cache
 
 
 def is_github_actions() -> bool:
@@ -177,6 +177,35 @@ def main():
         help="Enable verbose logging",
     )
 
+    # Lineage analysis command
+    lineage_parser = subparsers.add_parser(
+        "lineage",
+        help="Update lineage cache and export data.json",
+    )
+    lineage_parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("./config"),
+        help="Path to config directory (default: ./config)",
+    )
+    lineage_parser.add_argument(
+        "--data",
+        type=Path,
+        default=Path("./data"),
+        help="Path to data directory (default: ./data)",
+    )
+    lineage_parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("./docs"),
+        help="Path to output directory for data.json (default: ./docs)",
+    )
+    lineage_parser.add_argument(
+        "--verbose", "-v",
+        action="store_true",
+        help="Enable verbose logging",
+    )
+
     args = parser.parse_args()
 
     if args.command is None:
@@ -189,6 +218,8 @@ def main():
         cmd_generate(args)
     elif args.command == "build":
         cmd_build(args)
+    elif args.command == "lineage":
+        cmd_lineage(args)
 
 
 def cmd_discover(args):
@@ -409,6 +440,33 @@ def cmd_build(args):
         )
     
     return 0 if not gen_errors else 1
+
+
+def cmd_lineage(args):
+    """Run the lineage analysis command."""
+    verbose = args.verbose or is_github_actions()
+
+    gh_group_start("Lineage Analysis Configuration")
+    print(f"Config directory: {args.config}")
+    print(f"Data directory: {args.data}")
+    print(f"Output directory: {args.output}")
+    print(f"Verbose: {verbose}")
+    gh_group_end()
+
+    gh_group_start("Updating Lineage Cache")
+    stats = update_lineage_cache(args.data)
+    print(f"Total PDFs: {stats['total']}")
+    print(f"Updated: {stats['updated']}")
+    print(f"Reused: {stats['reused']}")
+    print(f"Removed: {stats['removed']}")
+    gh_group_end()
+
+    gh_group_start("Exporting data.json")
+    checks = load_checks(args.config / "checks.yaml")
+    documents = load_all_documents(args.data, checks)
+    generate_data_json(documents, checks, args.output)
+    print(f"Exported data.json with {len(documents)} documents")
+    gh_group_end()
 
 
 def write_job_summary(

--- a/src/mandate_pipeline/lineage.py
+++ b/src/mandate_pipeline/lineage.py
@@ -1,0 +1,125 @@
+"""Lineage analysis and caching for document linkage data."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+
+from .extractor import extract_text
+
+
+SYMBOL_PATTERN = re.compile(r"\b[A-Z](?:/[A-Z0-9.]+)+\b")
+
+
+def filename_to_symbol(filename: str) -> str:
+    """Convert a filename back to UN symbol."""
+    stem = filename.replace(".pdf", "")
+    return stem.replace("_", "/")
+
+
+def compute_last_modified_hash(pdf_path: Path) -> str:
+    """Compute a hash from the PDF's last-modified timestamp and size."""
+    stat = pdf_path.stat()
+    payload = f"{stat.st_mtime_ns}:{stat.st_size}".encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+def classify_symbol(symbol: str) -> str:
+    """Classify a document symbol into a coarse category."""
+    upper_symbol = symbol.upper()
+    if "/RES/" in upper_symbol:
+        return "resolution"
+    if re.search(r"/L\.\d+", upper_symbol):
+        return "proposal"
+    return "other"
+
+
+def normalize_symbol(symbol: str) -> str:
+    """Normalize a document symbol extracted from text."""
+    return symbol.strip().upper()
+
+
+def extract_linked_symbols(text: str, symbol: str) -> list[str]:
+    """Extract referenced document symbols from text."""
+    matches = {normalize_symbol(match) for match in SYMBOL_PATTERN.findall(text)}
+    matches.discard(normalize_symbol(symbol))
+    return sorted(matches)
+
+
+def load_lineage_cache(cache_path: Path) -> dict:
+    """Load lineage cache from disk."""
+    cache_path = Path(cache_path)
+    if not cache_path.exists():
+        return {"generated_at": None, "documents": {}}
+
+    with open(cache_path) as f:
+        data = json.load(f)
+
+    if "documents" not in data:
+        data["documents"] = {}
+    return data
+
+
+def save_lineage_cache(cache_path: Path, cache: dict) -> None:
+    """Persist lineage cache to disk."""
+    cache_path = Path(cache_path)
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+
+    cache["generated_at"] = datetime.now(timezone.utc).isoformat()
+    with open(cache_path, "w") as f:
+        json.dump(cache, f, indent=2)
+
+
+def update_lineage_cache(data_dir: Path, cache_path: Path | None = None) -> dict:
+    """Update lineage cache for PDFs under the data directory."""
+    data_dir = Path(data_dir)
+    cache_path = cache_path or (data_dir / "lineage.json")
+    cache = load_lineage_cache(cache_path)
+
+    pdfs_dir = data_dir / "pdfs"
+    documents = cache.get("documents", {})
+    existing_symbols = set()
+    updated = 0
+    reused = 0
+
+    if not pdfs_dir.exists():
+        save_lineage_cache(cache_path, {"documents": {}})
+        return {"total": 0, "updated": 0, "reused": 0, "removed": 0}
+
+    for pdf_path in pdfs_dir.glob("*.pdf"):
+        symbol = filename_to_symbol(pdf_path.stem)
+        existing_symbols.add(symbol)
+        last_modified_hash = compute_last_modified_hash(pdf_path)
+
+        cached = documents.get(symbol)
+        if cached and cached.get("last_modified_hash") == last_modified_hash:
+            reused += 1
+            continue
+
+        text = extract_text(pdf_path)
+        links = extract_linked_symbols(text, symbol)
+        classification = classify_symbol(symbol)
+
+        documents[symbol] = {
+            "last_modified_hash": last_modified_hash,
+            "classification": classification,
+            "links": links,
+        }
+        updated += 1
+
+    removed_symbols = [symbol for symbol in documents.keys() if symbol not in existing_symbols]
+    for symbol in removed_symbols:
+        del documents[symbol]
+
+    cache["documents"] = documents
+    save_lineage_cache(cache_path, cache)
+
+    return {
+        "total": len(existing_symbols),
+        "updated": updated,
+        "reused": reused,
+        "removed": len(removed_symbols),
+    }

--- a/src/mandate_pipeline/static_generator.py
+++ b/src/mandate_pipeline/static_generator.py
@@ -10,6 +10,7 @@ from jinja2 import Environment, FileSystemLoader
 from .checks import load_checks, run_checks
 from .extractor import extract_text, extract_operative_paragraphs
 from .pipeline import load_patterns
+from .lineage import load_lineage_cache
 
 
 def get_un_document_url(symbol: str) -> str:
@@ -75,6 +76,9 @@ def load_all_documents(data_dir: Path, checks: list) -> list[dict]:
     if not pdfs_dir.exists():
         return documents
 
+    lineage_cache = load_lineage_cache(data_dir / "lineage.json")
+    lineage_documents = lineage_cache.get("documents", {})
+
     for pdf_file in pdfs_dir.glob("*.pdf"):
         # Extract symbol from filename
         symbol = filename_to_symbol(pdf_file.stem)
@@ -99,6 +103,7 @@ def load_all_documents(data_dir: Path, checks: list) -> list[dict]:
                 "paragraphs": paragraphs,
                 "signals": signals,
                 "signal_summary": signal_summary,
+                "lineage": lineage_documents.get(symbol, {}),
                 "num_paragraphs": len(paragraphs),
                 "un_url": get_un_document_url(symbol),
             })
@@ -821,6 +826,8 @@ def generate_site_verbose(
     load_start_time = time.time()
     documents = []
     pdfs_dir = data_dir / "pdfs"
+    lineage_cache = load_lineage_cache(data_dir / "lineage.json")
+    lineage_documents = lineage_cache.get("documents", {})
 
     if pdfs_dir.exists():
         for pdf_file in pdfs_dir.glob("*.pdf"):
@@ -844,6 +851,7 @@ def generate_site_verbose(
                     "paragraphs": paragraphs,
                     "signals": signals,
                     "signal_summary": signal_summary,
+                    "lineage": lineage_documents.get(symbol, {}),
                     "num_paragraphs": len(paragraphs),
                     "un_url": get_un_document_url(symbol),
                 }


### PR DESCRIPTION
### Motivation
- Avoid reprocessing PDFs when nothing changed by persisting and reusing lineage extraction results. 
- Provide an explicit CLI entry point to update the lineage cache and export site `data.json` for the static site. 
- Reduce unnecessary site builds by triggering the build workflow only when the lineage cache or repo sources change.

### Description
- Added `src/mandate_pipeline/lineage.py` which computes a last-modified hash for each PDF, extracts referenced symbols, classifies documents, and persists a `lineage.json` cache via `update_lineage_cache` and helpers like `load_lineage_cache`/`save_lineage_cache`. 
- Added a `lineage` subcommand to `src/mandate_pipeline/cli.py` that runs `update_lineage_cache`, loads checks, builds documents with `load_all_documents`, and writes `data.json` using `generate_data_json`; also removed an unused `json` import and adjusted imports. 
- Updated `src/mandate_pipeline/static_generator.py` to read `lineage.json` via `load_lineage_cache` and attach lineage info to each document record used by `generate_data_json`. 
- Created an initial `data/lineage.json` placeholder and adjusted GitHub Actions: added `.github/workflows/linkage-analysis.yml` to run linkage analysis only when `data/pdfs/**` changed (with a pre-check to skip if no PDF changes), and narrowed `.github/workflows/build-site.yml` to trigger on changes to `data/lineage.json` or repo sources rather than all of `data/**`.

### Testing
- No automated tests were run for this change.
- Changes were committed locally and workflow files inspected to verify the conditional `pdf_changes` gating and updated push path filters succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6970f6cfb540832ebfc1738baf7fb1c2)