### PR TITLE
ci: run linkage analysis on lineage module changes

### DIFF
--- a/.github/workflows/linkage-analysis.yml
+++ b/.github/workflows/linkage-analysis.yml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'data/pdfs/**'
+      - 'src/mandate_pipeline/lineage.py'
   workflow_run:
     workflows:
       - Fetch Documents
@@ -28,11 +29,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Check for PDF changes
+      - name: Check for lineage inputs
         id: pdf_changes
         run: |
           if git rev-parse HEAD~1 >/dev/null 2>&1; then
-            if git diff --name-only HEAD~1..HEAD | rg '^data/pdfs/'; then
+            if git diff --name-only HEAD~1..HEAD | rg '^(data/pdfs/|src/mandate_pipeline/lineage\.py)'; then
               echo "has_changes=true" >> $GITHUB_OUTPUT
             else
               echo "has_changes=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
### Motivation
- Ensure the linkage analysis workflow runs when the lineage implementation changes by treating the lineage module as an input to the job.

### Description
- Add `src/mandate_pipeline/lineage.py` to the `push.paths` in `.github/workflows/linkage-analysis.yml` and rename the check step to `Check for lineage inputs`, updating the diff check to look for `data/pdfs/` or `src/mandate_pipeline/lineage.py`.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69710a0d16f4832ea7007bced5573e49)