### PR TITLE
Populate `base_proposal_symbol` for resolutions when linked to proposals

### DIFF
--- a/src/mandate_pipeline/static_generator.py
+++ b/src/mandate_pipeline/static_generator.py
@@ -216,6 +216,8 @@ def link_documents(documents: list[dict]) -> None:
         doc["linked_proposal_symbols"] = linked
         doc["link_method"] = "symbol_reference"
         doc["link_confidence"] = 1.0
+        if doc.get("base_proposal_symbol") is None:
+            doc["base_proposal_symbol"] = linked[0]
         for ref in linked:
             proposal = proposals_by_symbol.get(ref)
             if proposal is None:
@@ -269,6 +271,8 @@ def link_documents(documents: list[dict]) -> None:
             doc["linked_proposal_symbols"] = [best_match["symbol"]]
             doc["link_method"] = "title_agenda_fuzzy"
             doc["link_confidence"] = best_confidence
+            if doc.get("base_proposal_symbol") is None:
+                doc["base_proposal_symbol"] = best_match["symbol"]
 
             if best_match.get("linked_resolution_symbol") is None:
                 best_match["linked_resolution_symbol"] = doc["symbol"]


### PR DESCRIPTION
### Motivation
- Resolutions were often missing a `base_proposal_symbol` because that field was only inferred for proposals/amendments and not set when a resolution was linked to a proposal, causing many resolutions to remain without a base proposal.

### Description
- When linking documents in `link_documents` I now populate `base_proposal_symbol` for resolutions during both the `symbol_reference` and `title_agenda_fuzzy` linking paths by assigning the linked proposal symbol if the field is `None` in `src/mandate_pipeline/static_generator.py`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971100e7148832eb564f097aeec4a4d)