### PR TITLE
Ignore generated docs and add --clean-output option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,5 +42,6 @@ Thumbs.db
 
 # Project specific
 # Keep PDFs in data/pdfs/ (they're part of the cache)
-# Keep docs/ (generated static site for GitHub Pages)
+# Ignore docs/ (generated static site output)
 data/cache/
+docs/

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ mandate generate \
   --config ./config \
   --data ./data \
   --output ./docs \
+  --clean-output \
   --verbose
 ```
 
@@ -232,6 +233,7 @@ mandate generate \
 | `--config` | Directory containing checks.yaml and patterns.yaml |
 | `--data` | Directory with pdfs/ subdirectory |
 | `--output` | Output directory for static site |
+| `--clean-output` | Delete existing output directory contents before generation |
 | `--verbose` | Log each document processed |
 
 ### mandate build
@@ -243,6 +245,7 @@ mandate build \
   --config ./config \
   --data ./data \
   --output ./docs \
+  --clean-output \
   --max-misses 3 \
   --verbose
 ```

--- a/src/mandate_pipeline/cli.py
+++ b/src/mandate_pipeline/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import os
+import shutil
 import sys
 import time
 from pathlib import Path
@@ -136,6 +137,11 @@ def main():
         help="Path to output directory (default: ./docs)",
     )
     generate_parser.add_argument(
+        "--clean-output",
+        action="store_true",
+        help="Delete existing output directory contents before generation",
+    )
+    generate_parser.add_argument(
         "--verbose", "-v",
         action="store_true",
         help="Enable verbose logging",
@@ -163,6 +169,11 @@ def main():
         type=Path,
         default=Path("./docs"),
         help="Path to output directory (default: ./docs)",
+    )
+    build_parser.add_argument(
+        "--clean-output",
+        action="store_true",
+        help="Delete existing output directory contents before generation",
     )
     build_parser.add_argument(
         "--max-misses",
@@ -280,8 +291,16 @@ def cmd_generate(args):
     print(f"Config directory: {args.config}")
     print(f"Data directory: {args.data}")
     print(f"Output directory: {args.output}")
+    print(f"Clean output: {args.clean_output}")
     print(f"Verbose: {verbose}")
     gh_group_end()
+
+    if args.clean_output and args.output.exists():
+        gh_group_start("Cleaning Output")
+        print(f"Removing existing output directory: {args.output}")
+        shutil.rmtree(args.output)
+        args.output.mkdir(parents=True, exist_ok=True)
+        gh_group_end()
     
     # Run generation with verbose callback
     start_time = time.time()
@@ -378,6 +397,7 @@ def cmd_build(args):
         config=args.config,
         data=args.data,
         output=args.output,
+        clean_output=args.clean_output,
         verbose=verbose,
     )
     gen_stats, gen_errors, generate_duration = cmd_generate(generate_args)


### PR DESCRIPTION
### Motivation

- Prevent committing generated static site output by ignoring the `docs/` directory in git. 
- Provide a simple way to remove stale files from the output directory prior to site generation. 
- Document the new workflow so users can opt into cleaning the output when running the pipeline.

### Description

- Added `docs/` to `.gitignore` to exclude generated site artifacts from version control. 
- Added a `--clean-output` flag to both the `generate` and `build` commands in `src/mandate_pipeline/cli.py`. 
- Implemented output cleaning by importing `shutil` and removing the output directory with `shutil.rmtree()` when `--clean-output` is set, then recreating the directory. 
- Updated `README.md` to show `--clean-output` in the example commands and options table.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69725f5d1a28832eaee63e682df3900d)