### PR TITLE
Fix static navigation links in generated site

### DIFF
--- a/src/mandate_pipeline/templates/static/debug/extraction.html
+++ b/src/mandate_pipeline/templates/static/debug/extraction.html
@@ -2,14 +2,22 @@
 
 {% block title %}Extraction Verification - Mandate Pipeline{% endblock %}
 
-{% block nav_index %}../../index.html{% endblock %}
-{% block nav_documents %}../../documents/index.html{% endblock %}
+{% block nav_index %}../index.html{% endblock %}
+{% block nav_documents %}../documents/index.html{% endblock %}
+{% block nav_provenance %}../provenance/index.html{% endblock %}
+{% block nav_origin_matrix %}../origin_matrix.html{% endblock %}
+{% block nav_debug %}./index.html{% endblock %}
+{% block nav_linking %}./linking.html{% endblock %}
+{% block nav_orphans %}./orphans.html{% endblock %}
+{% block nav_fuzzy %}./fuzzy.html{% endblock %}
+{% block nav_extraction %}./extraction.html{% endblock %}
+{% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
 <!-- Breadcrumb -->
 <nav class="mb-8">
     <ol class="flex items-center gap-2 text-sm text-muted">
-        <li><a href="../../index.html" class="hover:text-un-blue transition-colors">Home</a></li>
+        <li><a href="../index.html" class="hover:text-un-blue transition-colors">Home</a></li>
         <li class="text-gray-300">/</li>
         <li><a href="./index.html" class="hover:text-un-blue transition-colors">Debug</a></li>
         <li class="text-gray-300">/</li>

--- a/src/mandate_pipeline/templates/static/debug/fuzzy.html
+++ b/src/mandate_pipeline/templates/static/debug/fuzzy.html
@@ -2,14 +2,22 @@
 
 {% block title %}Fuzzy Match Explorer - Mandate Pipeline{% endblock %}
 
-{% block nav_index %}../../index.html{% endblock %}
-{% block nav_documents %}../../documents/index.html{% endblock %}
+{% block nav_index %}../index.html{% endblock %}
+{% block nav_documents %}../documents/index.html{% endblock %}
+{% block nav_provenance %}../provenance/index.html{% endblock %}
+{% block nav_origin_matrix %}../origin_matrix.html{% endblock %}
+{% block nav_debug %}./index.html{% endblock %}
+{% block nav_linking %}./linking.html{% endblock %}
+{% block nav_orphans %}./orphans.html{% endblock %}
+{% block nav_fuzzy %}./fuzzy.html{% endblock %}
+{% block nav_extraction %}./extraction.html{% endblock %}
+{% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
 <!-- Breadcrumb -->
 <nav class="mb-8">
     <ol class="flex items-center gap-2 text-sm text-muted">
-        <li><a href="../../index.html" class="hover:text-un-blue transition-colors">Home</a></li>
+        <li><a href="../index.html" class="hover:text-un-blue transition-colors">Home</a></li>
         <li class="text-gray-300">/</li>
         <li><a href="./index.html" class="hover:text-un-blue transition-colors">Debug</a></li>
         <li class="text-gray-300">/</li>

--- a/src/mandate_pipeline/templates/static/debug/index.html
+++ b/src/mandate_pipeline/templates/static/debug/index.html
@@ -2,8 +2,16 @@
 
 {% block title %}Debug Tools - Mandate Pipeline{% endblock %}
 
-{% block nav_index %}../../index.html{% endblock %}
-{% block nav_documents %}../../documents/index.html{% endblock %}
+{% block nav_index %}../index.html{% endblock %}
+{% block nav_documents %}../documents/index.html{% endblock %}
+{% block nav_provenance %}../provenance/index.html{% endblock %}
+{% block nav_origin_matrix %}../origin_matrix.html{% endblock %}
+{% block nav_debug %}./index.html{% endblock %}
+{% block nav_linking %}./linking.html{% endblock %}
+{% block nav_orphans %}./orphans.html{% endblock %}
+{% block nav_fuzzy %}./fuzzy.html{% endblock %}
+{% block nav_extraction %}./extraction.html{% endblock %}
+{% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
 <!-- Breadcrumb -->

--- a/src/mandate_pipeline/templates/static/debug/linking.html
+++ b/src/mandate_pipeline/templates/static/debug/linking.html
@@ -2,14 +2,22 @@
 
 {% block title %}Linking Audit - Mandate Pipeline{% endblock %}
 
-{% block nav_index %}../../index.html{% endblock %}
-{% block nav_documents %}../../documents/index.html{% endblock %}
+{% block nav_index %}../index.html{% endblock %}
+{% block nav_documents %}../documents/index.html{% endblock %}
+{% block nav_provenance %}../provenance/index.html{% endblock %}
+{% block nav_origin_matrix %}../origin_matrix.html{% endblock %}
+{% block nav_debug %}./index.html{% endblock %}
+{% block nav_linking %}./linking.html{% endblock %}
+{% block nav_orphans %}./orphans.html{% endblock %}
+{% block nav_fuzzy %}./fuzzy.html{% endblock %}
+{% block nav_extraction %}./extraction.html{% endblock %}
+{% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
 <!-- Breadcrumb -->
 <nav class="mb-8">
     <ol class="flex items-center gap-2 text-sm text-muted">
-        <li><a href="../../index.html" class="hover:text-un-blue transition-colors">Home</a></li>
+        <li><a href="../index.html" class="hover:text-un-blue transition-colors">Home</a></li>
         <li class="text-gray-300">/</li>
         <li><a href="./index.html" class="hover:text-un-blue transition-colors">Debug</a></li>
         <li class="text-gray-300">/</li>

--- a/src/mandate_pipeline/templates/static/debug/orphans.html
+++ b/src/mandate_pipeline/templates/static/debug/orphans.html
@@ -2,14 +2,22 @@
 
 {% block title %}Unlinked Resolutions - Mandate Pipeline{% endblock %}
 
-{% block nav_index %}../../index.html{% endblock %}
-{% block nav_documents %}../../documents/index.html{% endblock %}
+{% block nav_index %}../index.html{% endblock %}
+{% block nav_documents %}../documents/index.html{% endblock %}
+{% block nav_provenance %}../provenance/index.html{% endblock %}
+{% block nav_origin_matrix %}../origin_matrix.html{% endblock %}
+{% block nav_debug %}./index.html{% endblock %}
+{% block nav_linking %}./linking.html{% endblock %}
+{% block nav_orphans %}./orphans.html{% endblock %}
+{% block nav_fuzzy %}./fuzzy.html{% endblock %}
+{% block nav_extraction %}./extraction.html{% endblock %}
+{% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
 <!-- Breadcrumb -->
 <nav class="mb-8">
     <ol class="flex items-center gap-2 text-sm text-muted">
-        <li><a href="../../index.html" class="hover:text-un-blue transition-colors">Home</a></li>
+        <li><a href="../index.html" class="hover:text-un-blue transition-colors">Home</a></li>
         <li class="text-gray-300">/</li>
         <li><a href="./index.html" class="hover:text-un-blue transition-colors">Debug</a></li>
         <li class="text-gray-300">/</li>

--- a/src/mandate_pipeline/templates/static/document_detail.html
+++ b/src/mandate_pipeline/templates/static/document_detail.html
@@ -4,6 +4,14 @@
 
 {% block nav_index %}../index.html{% endblock %}
 {% block nav_documents %}./index.html{% endblock %}
+{% block nav_provenance %}../provenance/index.html{% endblock %}
+{% block nav_origin_matrix %}../origin_matrix.html{% endblock %}
+{% block nav_debug %}../debug/index.html{% endblock %}
+{% block nav_linking %}../debug/linking.html{% endblock %}
+{% block nav_orphans %}../debug/orphans.html{% endblock %}
+{% block nav_fuzzy %}../debug/fuzzy.html{% endblock %}
+{% block nav_extraction %}../debug/extraction.html{% endblock %}
+{% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
 <!-- Breadcrumb -->

--- a/src/mandate_pipeline/templates/static/documents.html
+++ b/src/mandate_pipeline/templates/static/documents.html
@@ -4,6 +4,14 @@
 
 {% block nav_index %}../index.html{% endblock %}
 {% block nav_documents %}./index.html{% endblock %}
+{% block nav_provenance %}../provenance/index.html{% endblock %}
+{% block nav_origin_matrix %}../origin_matrix.html{% endblock %}
+{% block nav_debug %}../debug/index.html{% endblock %}
+{% block nav_linking %}../debug/linking.html{% endblock %}
+{% block nav_orphans %}../debug/orphans.html{% endblock %}
+{% block nav_fuzzy %}../debug/fuzzy.html{% endblock %}
+{% block nav_extraction %}../debug/extraction.html{% endblock %}
+{% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
 <!-- Header -->

--- a/src/mandate_pipeline/templates/static/pattern.html
+++ b/src/mandate_pipeline/templates/static/pattern.html
@@ -4,6 +4,14 @@
 
 {% block nav_index %}../index.html{% endblock %}
 {% block nav_documents %}../documents/index.html{% endblock %}
+{% block nav_provenance %}../provenance/index.html{% endblock %}
+{% block nav_origin_matrix %}../origin_matrix.html{% endblock %}
+{% block nav_debug %}../debug/index.html{% endblock %}
+{% block nav_linking %}../debug/linking.html{% endblock %}
+{% block nav_orphans %}../debug/orphans.html{% endblock %}
+{% block nav_fuzzy %}../debug/fuzzy.html{% endblock %}
+{% block nav_extraction %}../debug/extraction.html{% endblock %}
+{% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
 <!-- Breadcrumb -->

--- a/src/mandate_pipeline/templates/static/pattern_signal.html
+++ b/src/mandate_pipeline/templates/static/pattern_signal.html
@@ -4,6 +4,14 @@
 
 {% block nav_index %}../index.html{% endblock %}
 {% block nav_documents %}../documents/index.html{% endblock %}
+{% block nav_provenance %}../provenance/index.html{% endblock %}
+{% block nav_origin_matrix %}../origin_matrix.html{% endblock %}
+{% block nav_debug %}../debug/index.html{% endblock %}
+{% block nav_linking %}../debug/linking.html{% endblock %}
+{% block nav_orphans %}../debug/orphans.html{% endblock %}
+{% block nav_fuzzy %}../debug/fuzzy.html{% endblock %}
+{% block nav_extraction %}../debug/extraction.html{% endblock %}
+{% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
 <!-- Breadcrumb -->

--- a/src/mandate_pipeline/templates/static/provenance.html
+++ b/src/mandate_pipeline/templates/static/provenance.html
@@ -4,6 +4,14 @@
 
 {% block nav_index %}../index.html{% endblock %}
 {% block nav_documents %}../documents/index.html{% endblock %}
+{% block nav_provenance %}./index.html{% endblock %}
+{% block nav_origin_matrix %}../origin_matrix.html{% endblock %}
+{% block nav_debug %}../debug/index.html{% endblock %}
+{% block nav_linking %}../debug/linking.html{% endblock %}
+{% block nav_orphans %}../debug/orphans.html{% endblock %}
+{% block nav_fuzzy %}../debug/fuzzy.html{% endblock %}
+{% block nav_extraction %}../debug/extraction.html{% endblock %}
+{% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
 <!-- Breadcrumb -->
@@ -41,7 +49,7 @@
             <span class="text-sm font-medium text-gray-700">Linking Coverage:</span>
             <span class="text-sm text-muted ml-2">{{ coverage.linked }} of {{ coverage.total }} resolutions linked ({{ coverage.percentage }}%)</span>
         </div>
-        <a href="./debug/orphans.html" class="text-sm text-un-blue hover:underline">
+        <a href="../debug/orphans.html" class="text-sm text-un-blue hover:underline">
             View {{ coverage.unlinked }} unlinked &rarr;
         </a>
     </div>

--- a/src/mandate_pipeline/templates/static/signal.html
+++ b/src/mandate_pipeline/templates/static/signal.html
@@ -4,6 +4,14 @@
 
 {% block nav_index %}../index.html{% endblock %}
 {% block nav_documents %}../documents/index.html{% endblock %}
+{% block nav_provenance %}../provenance/index.html{% endblock %}
+{% block nav_origin_matrix %}../origin_matrix.html{% endblock %}
+{% block nav_debug %}../debug/index.html{% endblock %}
+{% block nav_linking %}../debug/linking.html{% endblock %}
+{% block nav_orphans %}../debug/orphans.html{% endblock %}
+{% block nav_fuzzy %}../debug/fuzzy.html{% endblock %}
+{% block nav_extraction %}../debug/extraction.html{% endblock %}
+{% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
 <!-- Breadcrumb -->


### PR DESCRIPTION
### Motivation
- Static site pages nested under subfolders had top-menu links resolving incorrectly because templates did not override the navigation blocks with the correct relative paths.
- Several debug and provenance pages used wrong relative targets for the "Home" and "Unlinked" links causing broken navigation from generated pages.

### Description
- Added explicit nav block overrides (`nav_index`, `nav_documents`, `nav_provenance`, `nav_origin_matrix`, `nav_debug`, `nav_linking`, `nav_orphans`, `nav_fuzzy`, `nav_extraction`, `nav_api`) to static templates in nested folders so the base header produces correct relative links.
- Updated the following static templates: `documents.html`, `document_detail.html`, `signal.html`, `pattern.html`, `pattern_signal.html`, `provenance.html`, and debug templates under `debug/` (`index.html`, `linking.html`, `orphans.html`, `fuzzy.html`, `extraction.html`).
- Fixed the provenance page link to the debug unlinked view by changing the target from `./debug/orphans.html` to `../debug/orphans.html` and adjusted breadcrumb "Home" links for debug pages to use the correct relative path.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697278897438832e992e53d5f6b3e537)