### PR TITLE
Add data/cache/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ htmlcov/
 # OS
 .DS_Store
 Thumbs.db
+
+# Project specific
+data/cache/


### PR DESCRIPTION
## Summary
Updated `.gitignore` to exclude the `data/cache/` directory from version control.

## Changes
- Added `data/cache/` to the project-specific section of `.gitignore`

## Details
This prevents cached data files from being accidentally committed to the repository. The cache directory is typically generated at runtime and should not be tracked as part of the codebase.