### PR TITLE
Add amendment text extraction and remove document embed panel

### DIFF
--- a/src/mandate_pipeline/templates/static/signals_unified.html
+++ b/src/mandate_pipeline/templates/static/signals_unified.html
@@ -65,11 +65,9 @@
                     <div class="flex items-start justify-between gap-4">
                         <div class="flex-1 min-w-0">
                             <div class="flex items-center gap-3 mb-1">
-                                <button class="view-doc-btn font-semibold text-gray-900 hover:text-un-blue transition-colors text-left"
-                                        data-symbol="{{ doc.symbol }}"
-                                        data-un-url="{{ doc.un_url }}">
+                                <span class="font-semibold text-gray-900">
                                     {{ doc.symbol }}
-                                </button>
+                                </span>
                                 {% if doc.doc_type == 'proposal' %}
                                 <span class="px-2 py-0.5 rounded text-xs font-medium bg-amber-100 text-amber-800">
                                     Proposal
@@ -146,27 +144,6 @@
         </div>
     </div>
 
-    <!-- Document Embed Panel -->
-    <div id="embed-panel" class="hidden w-[500px] flex-shrink-0 sticky top-24 h-[calc(100vh-8rem)]">
-        <div class="border border-gray-200 rounded-lg overflow-hidden h-full flex flex-col bg-white shadow-lg">
-            <div class="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between">
-                <div class="flex items-center gap-2">
-                    <span id="embed-symbol" class="font-semibold text-gray-900"></span>
-                    <a id="embed-external-link" href="#" target="_blank" class="text-xs text-muted hover:text-un-blue">
-                        Open in new tab
-                    </a>
-                </div>
-                <button id="close-embed" class="p-1 text-gray-400 hover:text-gray-600 transition-colors">
-                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
-                    </svg>
-                </button>
-            </div>
-            <div class="flex-1 bg-gray-100">
-                <iframe id="embed-iframe" class="w-full h-full border-0" src="about:blank"></iframe>
-            </div>
-        </div>
-    </div>
 </div>
 
 <script>
@@ -179,12 +156,6 @@ document.addEventListener('DOMContentLoaded', function() {
     const documentCards = document.querySelectorAll('.document-card');
     const emptyState = document.getElementById('empty-state');
     const statsText = document.getElementById('stats-text');
-    const embedPanel = document.getElementById('embed-panel');
-    const embedIframe = document.getElementById('embed-iframe');
-    const embedSymbol = document.getElementById('embed-symbol');
-    const embedExternalLink = document.getElementById('embed-external-link');
-    const closeEmbedBtn = document.getElementById('close-embed');
-    const mainContent = document.getElementById('main-content');
 
     // Parse URL params and set initial filter state
     function initFromUrl() {
@@ -283,21 +254,6 @@ document.addEventListener('DOMContentLoaded', function() {
         updateUrl();
     }
 
-    // Document embed functionality
-    function showEmbed(symbol, url) {
-        embedSymbol.textContent = symbol;
-        embedExternalLink.href = url;
-        embedIframe.src = url;
-        embedPanel.classList.remove('hidden');
-        mainContent.classList.add('embed-open');
-    }
-
-    function hideEmbed() {
-        embedPanel.classList.add('hidden');
-        embedIframe.src = 'about:blank';
-        mainContent.classList.remove('embed-open');
-    }
-
     // Event listeners
     sourceFilter.addEventListener('change', applyFilters);
     signalFilter.addEventListener('change', applyFilters);
@@ -310,27 +266,10 @@ document.addEventListener('DOMContentLoaded', function() {
         applyFilters();
     });
 
-    closeEmbedBtn.addEventListener('click', hideEmbed);
-
-    // View document button clicks
-    document.querySelectorAll('.view-doc-btn').forEach(btn => {
-        btn.addEventListener('click', function() {
-            const symbol = this.dataset.symbol;
-            const url = this.dataset.unUrl;
-            showEmbed(symbol, url);
-        });
-    });
-
     // Initialize from URL
     initFromUrl();
 });
 </script>
-
-<style>
-.embed-open #document-list {
-    max-width: calc(100% - 520px);
-}
-</style>
 {% endblock %}
 
 {% block footer %}


### PR DESCRIPTION
## Summary
This PR adds support for extracting text from amendment documents that lack standard numbered operative paragraphs, and removes the document embed panel from the signal browser UI.

## Key Changes

### Amendment Text Extraction
- **New function `extract_amendment_text()`** in `extractor.py`: Extracts body text from amendment documents by identifying header/footer markers and returning the content as a single paragraph for signal detection
  - Recognizes common amendment preamble patterns (e.g., "Recalling", "Noting", "In paragraph")
  - Identifies and skips document headers (UN document IDs, agenda items, dates)
  - Identifies and skips footers (document IDs, barcodes, Geneva IDs)
  - Returns normalized text only if meaningful (>20 characters)

### Amendment Processing Logic
- Updated `load_all_documents()` and `process_pdf()` in `generation.py` to handle amendments without numbered paragraphs:
  - First attempts to extract lettered paragraphs
  - Falls back to body text extraction via `extract_amendment_text()`
  - Converts extracted content to numeric paragraph keys for consistency with signal detection

### UI Simplification
- **Removed document embed panel** from `signals_unified.html`:
  - Deleted the side panel iframe that displayed UN documents
  - Removed associated JavaScript functionality (`showEmbed()`, `hideEmbed()`)
  - Removed event listeners for document view buttons
  - Removed CSS styling for embed panel layout
  - Document symbols now display as plain text instead of clickable buttons

## Implementation Details
- Amendment text extraction uses regex patterns to identify structural boundaries
- Whitespace normalization ensures consistent text processing
- Fallback extraction strategy ensures amendments are processed even without standard paragraph structure
- UI changes reduce complexity while maintaining document reference visibility