### PR TITLE
Remove document pages and debug features, add signals info page

### DIFF
--- a/src/mandate_pipeline/linking.py
+++ b/src/mandate_pipeline/linking.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import Any
 
 import requests
-from rapidfuzz import fuzz
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
@@ -224,13 +223,6 @@ def normalize_symbol(symbol: str) -> str:
     return symbol.strip().upper()
 
 
-def normalize_title(title: str | None) -> str:
-    """Normalize a title for fuzzy matching."""
-    if not title:
-        return ""
-    # Strip resolution/decision number prefix like "80/60." or "80/60 "
-    title = re.sub(r"^\d+/\d+[.\s]+", "", title)
-    return re.sub(r"[^a-z0-9]+", " ", title.lower()).strip()
 
 
 def is_resolution(symbol: str) -> bool:
@@ -467,75 +459,6 @@ def link_documents(documents: list[dict], use_undl_metadata: bool = True) -> Non
             if proposal.get("linked_resolution_symbol") is None:
                 proposal["linked_resolution_symbol"] = doc["symbol"]
 
-    # Pass 2: Fuzzy title matching with agenda overlap
-    for doc in documents:
-        if not is_resolution(doc["symbol"]):
-            continue
-        if doc.get("linked_proposal_symbols"):
-            continue
-
-        audit = _linking_audit[doc["symbol"]]
-        audit["pass2_fuzzy"]["attempted"] = True
-
-        title = normalize_title(doc.get("title", ""))
-        if not title:
-            continue
-        agenda_items = set(doc.get("agenda_items") or [])
-
-        best_match = None
-        best_score = 0.0
-        candidates = []
-
-        for proposal in proposals:
-            if proposal.get("linked_resolution_symbol") not in (None, doc["symbol"]):
-                continue
-
-            proposal_title = normalize_title(proposal.get("title", ""))
-            if not proposal_title:
-                continue
-
-            proposal_agenda = set(proposal.get("agenda_items") or [])
-            agenda_overlap = bool(agenda_items and proposal_agenda and agenda_items.intersection(proposal_agenda))
-
-            if agenda_items and proposal_agenda and not agenda_overlap:
-                continue
-
-            similarity = fuzz.ratio(title, proposal_title)
-
-            # Record all candidates with > 50% similarity for audit
-            if similarity >= 50:
-                candidates.append({
-                    "symbol": proposal["symbol"],
-                    "title": proposal.get("title", ""),
-                    "normalized_title": proposal_title,
-                    "score": similarity,
-                    "agenda_overlap": agenda_overlap,
-                })
-
-            if similarity < 85:
-                continue
-
-            if similarity > best_score:
-                best_score = similarity
-                best_match = proposal
-
-        # Sort candidates by score
-        candidates.sort(key=lambda x: x["score"], reverse=True)
-        audit["pass2_fuzzy"]["candidates"] = candidates[:10]  # Top 10
-
-        if best_match:
-            doc["linked_proposal_symbols"] = [best_match["symbol"]]
-            audit["pass2_fuzzy"]["best_match"] = best_match["symbol"]
-            audit["pass2_fuzzy"]["best_score"] = best_score
-            audit["pass2_fuzzy"]["agenda_overlap"] = any(
-                c["agenda_overlap"] for c in candidates if c["symbol"] == best_match["symbol"]
-            )
-            audit["final_method"] = "fuzzy"
-            audit["final_linked"] = [best_match["symbol"]]
-            audit["confidence"] = int(best_score)
-
-            if best_match.get("linked_resolution_symbol") is None:
-                best_match["linked_resolution_symbol"] = doc["symbol"]
 
 
 def annotate_linkage(documents: list[dict]) -> None:

--- a/src/mandate_pipeline/templates/static/base.html
+++ b/src/mandate_pipeline/templates/static/base.html
@@ -46,23 +46,8 @@
                     <span class="text-lg font-semibold text-gray-900 group-hover:text-un-blue transition-colors">Mandate Pipeline</span>
                 </a>
                 <nav class="flex items-center gap-6">
-                    <a href="{% block nav_signals %}./signals.html{% endblock %}" class="text-muted hover:text-un-blue transition-colors text-sm font-medium">Signals</a>
-                    <a href="{% block nav_documents %}./documents/index.html{% endblock %}" class="text-muted hover:text-un-blue transition-colors text-sm font-medium">Documents</a>
-                    <div class="relative group">
-                        <button class="text-muted hover:text-un-blue transition-colors text-sm font-medium flex items-center gap-1">
-                            Debug
-                            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-                            </svg>
-                        </button>
-                        <div class="absolute right-0 mt-2 w-48 bg-white rounded-lg shadow-lg border border-gray-200 opacity-0 invisible group-hover:opacity-100 group-hover:visible transition-all z-50">
-                            <a href="{% block nav_debug %}./debug/index.html{% endblock %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-un-blue rounded-t-lg">Overview</a>
-                            <a href="{% block nav_linking %}./debug/linking.html{% endblock %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-un-blue">Linking Audit</a>
-                            <a href="{% block nav_orphans %}./debug/orphans.html{% endblock %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-un-blue">Unlinked</a>
-                            <a href="{% block nav_fuzzy %}./debug/fuzzy.html{% endblock %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-un-blue">Fuzzy Matches</a>
-                            <a href="{% block nav_extraction %}./debug/extraction.html{% endblock %}" class="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 hover:text-un-blue rounded-b-lg">Extraction</a>
-                        </div>
-                    </div>
+                    <a href="{% block nav_signals %}./signals.html{% endblock %}" class="text-muted hover:text-un-blue transition-colors text-sm font-medium">Browser</a>
+                    <a href="{% block nav_signals_info %}./signals-info.html{% endblock %}" class="text-muted hover:text-un-blue transition-colors text-sm font-medium">About Signals</a>
                     <a href="{% block nav_api %}./data.json{% endblock %}" class="text-muted hover:text-un-blue transition-colors text-sm font-medium">API</a>
                 </nav>
             </div>

--- a/src/mandate_pipeline/templates/static/index.html
+++ b/src/mandate_pipeline/templates/static/index.html
@@ -4,7 +4,7 @@
 
 {% block nav_index %}./index.html{% endblock %}
 {% block nav_signals %}./signals.html{% endblock %}
-{% block nav_documents %}./documents/index.html{% endblock %}
+{% block nav_signals_info %}./signals-info.html{% endblock %}
 
 {% block content %}
 <!-- Hero -->
@@ -17,7 +17,6 @@
 
 <!-- Signal Source Matrix (Origin × Signal) -->
 <div class="mb-12">
-    <h2 class="text-sm font-semibold text-gray-500 uppercase tracking-wide mb-4">Signal Source Matrix</h2>
     <div class="overflow-x-auto">
         <table class="w-full">
             <thead>
@@ -61,8 +60,10 @@
                         {% if count > 0 %}
                         <a href="./signals.html?source={{ origin_code|urlencode }}&signal={{ check.signal|urlencode }}"
                            class="inline-flex items-center justify-center min-w-[2rem] px-2 py-1 rounded-full text-sm font-medium transition-all hover:scale-110
-                            {% if 'agenda' in check.signal|lower %}bg-blue-50 text-blue-700 hover:bg-blue-100
-                            {% elif 'pga' in check.signal|lower %}bg-purple-50 text-purple-700 hover:bg-purple-100
+                            {% if check.signal == 'agenda' %}bg-blue-50 text-blue-700 hover:bg-blue-100
+                            {% elif check.signal == 'PGA' %}bg-purple-50 text-purple-700 hover:bg-purple-100
+                            {% elif check.signal == 'process' %}bg-amber-50 text-amber-700 hover:bg-amber-100
+                            {% elif check.signal == 'report' %}bg-green-50 text-green-700 hover:bg-green-100
                             {% else %}bg-gray-100 text-gray-700 hover:bg-gray-200{% endif %}">
                             {{ count }}
                         </a>
@@ -86,8 +87,10 @@
                     <td class="text-center py-4 px-4">
                         <a href="./signals.html?signal={{ check.signal|urlencode }}"
                            class="inline-flex items-center justify-center min-w-[2rem] px-2 py-1 rounded-full text-sm font-bold
-                            {% if 'agenda' in check.signal|lower %}bg-blue-100 text-blue-800
-                            {% elif 'pga' in check.signal|lower %}bg-purple-100 text-purple-800
+                            {% if check.signal == 'agenda' %}bg-blue-100 text-blue-800
+                            {% elif check.signal == 'PGA' %}bg-purple-100 text-purple-800
+                            {% elif check.signal == 'process' %}bg-amber-100 text-amber-800
+                            {% elif check.signal == 'report' %}bg-green-100 text-green-800
                             {% else %}bg-gray-200 text-gray-800{% endif %}">
                             {{ total }}
                         </a>

--- a/src/mandate_pipeline/templates/static/origin_matrix.html
+++ b/src/mandate_pipeline/templates/static/origin_matrix.html
@@ -4,7 +4,7 @@
 
 {% block nav_index %}./index.html{% endblock %}
 {% block nav_signals %}./signals.html{% endblock %}
-{% block nav_documents %}./documents/index.html{% endblock %}
+{% block nav_signals_info %}./signals-info.html{% endblock %}
 
 {% block content %}
 <!-- Header -->
@@ -57,10 +57,12 @@
                 {% set count = origin_data.get(check.signal, 0) %}
                 <td class="text-center py-4 px-4">
                     {% if count > 0 %}
-                    <a href="./origin_signal/{{ origin_code|lower }}_{{ check.signal|lower|replace(' ', '-') }}.html"
+                    <a href="./signals.html?source={{ origin_code|urlencode }}&signal={{ check.signal|urlencode }}"
                        class="inline-flex items-center justify-center min-w-[2rem] px-2 py-1 rounded-full text-sm font-medium transition-all hover:scale-110
-                        {% if 'agenda' in check.signal|lower %}bg-blue-50 text-blue-700 hover:bg-blue-100
-                        {% elif 'pga' in check.signal|lower %}bg-purple-50 text-purple-700 hover:bg-purple-100
+                        {% if check.signal == 'agenda' %}bg-blue-50 text-blue-700 hover:bg-blue-100
+                        {% elif check.signal == 'PGA' %}bg-purple-50 text-purple-700 hover:bg-purple-100
+                        {% elif check.signal == 'process' %}bg-amber-50 text-amber-700 hover:bg-amber-100
+                        {% elif check.signal == 'report' %}bg-green-50 text-green-700 hover:bg-green-100
                         {% else %}bg-gray-100 text-gray-700 hover:bg-gray-200{% endif %}">
                         {{ count }}
                     </a>
@@ -83,8 +85,10 @@
                 {% set total = signal_totals.get(check.signal, 0) %}
                 <td class="text-center py-4 px-4">
                     <span class="inline-flex items-center justify-center min-w-[2rem] px-2 py-1 rounded-full text-sm font-bold
-                        {% if 'agenda' in check.signal|lower %}bg-blue-100 text-blue-800
-                        {% elif 'pga' in check.signal|lower %}bg-purple-100 text-purple-800
+                        {% if check.signal == 'agenda' %}bg-blue-100 text-blue-800
+                        {% elif check.signal == 'PGA' %}bg-purple-100 text-purple-800
+                        {% elif check.signal == 'process' %}bg-amber-100 text-amber-800
+                        {% elif check.signal == 'report' %}bg-green-100 text-green-800
                         {% else %}bg-gray-200 text-gray-800{% endif %}">
                         {{ total }}
                     </span>
@@ -141,8 +145,10 @@
             <div>
                 <div class="flex items-center justify-between mb-1">
                     <span class="text-sm font-medium
-                        {% if 'agenda' in check.signal|lower %}text-blue-700
-                        {% elif 'pga' in check.signal|lower %}text-purple-700
+                        {% if check.signal == 'agenda' %}text-blue-700
+                        {% elif check.signal == 'PGA' %}text-purple-700
+                        {% elif check.signal == 'process' %}text-amber-700
+                        {% elif check.signal == 'report' %}text-green-700
                         {% else %}text-gray-700{% endif %}">
                         {{ check.signal }}
                     </span>
@@ -150,8 +156,10 @@
                 </div>
                 <div class="h-2 bg-gray-100 rounded-full overflow-hidden">
                     <div class="h-full rounded-full
-                        {% if 'agenda' in check.signal|lower %}bg-blue-400
-                        {% elif 'pga' in check.signal|lower %}bg-purple-400
+                        {% if check.signal == 'agenda' %}bg-blue-400
+                        {% elif check.signal == 'PGA' %}bg-purple-400
+                        {% elif check.signal == 'process' %}bg-amber-400
+                        {% elif check.signal == 'report' %}bg-green-400
                         {% else %}bg-gray-400{% endif %}"
                          style="width: {{ pct }}%"></div>
                 </div>

--- a/src/mandate_pipeline/templates/static/pattern.html
+++ b/src/mandate_pipeline/templates/static/pattern.html
@@ -4,12 +4,7 @@
 
 {% block nav_index %}../index.html{% endblock %}
 {% block nav_signals %}../signals.html{% endblock %}
-{% block nav_documents %}../documents/index.html{% endblock %}
-{% block nav_debug %}../debug/index.html{% endblock %}
-{% block nav_linking %}../debug/linking.html{% endblock %}
-{% block nav_orphans %}../debug/orphans.html{% endblock %}
-{% block nav_fuzzy %}../debug/fuzzy.html{% endblock %}
-{% block nav_extraction %}../debug/extraction.html{% endblock %}
+{% block nav_signals_info %}../signals-info.html{% endblock %}
 {% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
@@ -83,31 +78,30 @@
             <!-- Document Header -->
             <div class="bg-gray-50 px-4 py-3 border-b border-gray-200 flex items-center justify-between">
                 <div class="flex items-center gap-3">
-                    <a href="../documents/{{ doc.symbol|replace('/', '_') }}.html" class="font-semibold text-gray-900 hover:text-un-blue transition-colors">
+                    <span class="font-semibold text-gray-900">
                         {{ doc.symbol }}
-                    </a>
+                    </span>
                     <span class="text-sm text-muted">{{ doc.num_paragraphs }} paragraphs</span>
                     {% if is_adopted and doc.adopted_by %}
                     <span class="text-xs text-muted">
-                        Adopted by
-                        <a href="../documents/{{ doc.adopted_by|replace('/', '_') }}.html" class="hover:text-un-blue transition-colors">
-                            {{ doc.adopted_by }}
-                        </a>
+                        Adopted by {{ doc.adopted_by }}
                     </span>
                     {% endif %}
                     {% for check in checks %}
                     {% set count = doc.signal_summary.get(check.signal, 0) %}
                     {% if count > 0 %}
                     <span class="px-2 py-0.5 rounded-full text-xs font-medium
-                        {% if 'agenda' in check.signal|lower %}bg-blue-50 text-blue-700
-                        {% elif 'pga' in check.signal|lower %}bg-purple-50 text-purple-700
+                        {% if check.signal == 'agenda' %}bg-blue-50 text-blue-700
+                        {% elif check.signal == 'PGA' %}bg-purple-50 text-purple-700
+                        {% elif check.signal == 'process' %}bg-amber-50 text-amber-700
+                        {% elif check.signal == 'report' %}bg-green-50 text-green-700
                         {% else %}bg-gray-100 text-gray-700{% endif %}">
                         {{ check.signal }}: {{ count }}
                     </span>
                     {% endif %}
                     {% endfor %}
                 </div>
-                <a href="{{ doc.un_url }}" target="_blank" class="text-sm text-muted hover:text-un-blue transition-colors">PDF ↗</a>
+                <a href="{{ doc.un_url }}" target="_blank" class="text-sm text-muted hover:text-un-blue transition-colors">View PDF</a>
             </div>
             
             <!-- Paragraphs -->
@@ -115,24 +109,25 @@
             <div class="divide-y divide-gray-100">
                 {% for para in doc.signal_paragraphs %}
                 <div class="px-4 py-3 flex gap-4">
-                    <div class="flex-shrink-0">
-                        <a href="../documents/{{ doc.symbol|replace('/', '_') }}.html#para-{{ para.number }}" 
-                           class="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-gray-100 text-gray-700 font-medium text-sm hover:bg-un-blue hover:text-white transition-colors">
+                    <div class="flex-shrink-0 text-center">
+                        <div class="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-gray-100 text-gray-700 font-medium text-sm">
                             {{ para.number }}
-                        </a>
-                    </div>
-                    <div class="flex-1">
-                        <p class="text-gray-700 leading-relaxed text-sm">{{ para.text|highlight_signals(para.signals) }}</p>
-                        <div class="mt-1 flex gap-1">
+                        </div>
+                        <div class="flex flex-col gap-1 mt-2">
                             {% for signal in para.signals %}
                             <span class="px-1.5 py-0.5 rounded text-xs font-medium
-                                {% if 'agenda' in signal|lower %}bg-blue-50 text-blue-700
-                                {% elif 'pga' in signal|lower %}bg-purple-50 text-purple-700
+                                {% if signal == 'agenda' %}bg-blue-100 text-blue-700
+                                {% elif signal == 'PGA' %}bg-purple-100 text-purple-700
+                                {% elif signal == 'process' %}bg-amber-100 text-amber-700
+                                {% elif signal == 'report' %}bg-green-100 text-green-700
                                 {% else %}bg-gray-100 text-gray-700{% endif %}">
                                 {{ signal }}
                             </span>
                             {% endfor %}
                         </div>
+                    </div>
+                    <div class="flex-1">
+                        <p class="text-gray-700 leading-relaxed text-sm">{{ para.text|highlight_signals(para.signals) }}</p>
                     </div>
                 </div>
                 {% endfor %}

--- a/src/mandate_pipeline/templates/static/pattern_signal.html
+++ b/src/mandate_pipeline/templates/static/pattern_signal.html
@@ -4,12 +4,7 @@
 
 {% block nav_index %}../index.html{% endblock %}
 {% block nav_signals %}../signals.html{% endblock %}
-{% block nav_documents %}../documents/index.html{% endblock %}
-{% block nav_debug %}../debug/index.html{% endblock %}
-{% block nav_linking %}../debug/linking.html{% endblock %}
-{% block nav_orphans %}../debug/orphans.html{% endblock %}
-{% block nav_fuzzy %}../debug/fuzzy.html{% endblock %}
-{% block nav_extraction %}../debug/extraction.html{% endblock %}
+{% block nav_signals_info %}../signals-info.html{% endblock %}
 {% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
@@ -51,36 +46,36 @@
         <!-- Document Header -->
         <div class="bg-gray-50 px-4 py-3 border-b border-gray-200 flex items-center justify-between">
             <div class="flex items-center gap-3">
-                <a href="../documents/{{ doc.symbol|replace('/', '_') }}.html" class="font-semibold text-gray-900 hover:text-un-blue transition-colors">
+                <span class="font-semibold text-gray-900">
                     {{ doc.symbol }}
-                </a>
-                <span class="px-2 py-0.5 rounded-full text-xs font-medium
-                    {% if 'agenda' in signal|lower %}bg-blue-50 text-blue-700
-                    {% elif 'pga' in signal|lower %}bg-purple-50 text-purple-700
-                    {% else %}bg-gray-100 text-gray-700{% endif %}">
-                    {{ doc_paras|length }} paragraph{% if doc_paras|length != 1 %}s{% endif %}
                 </span>
                 {% if is_adopted and doc.adopted_by %}
                 <span class="text-xs text-muted">
-                    Adopted by
-                    <a href="../documents/{{ doc.adopted_by|replace('/', '_') }}.html" class="hover:text-un-blue transition-colors">
-                        {{ doc.adopted_by }}
-                    </a>
+                    Adopted by {{ doc.adopted_by }}
                 </span>
                 {% endif %}
             </div>
-            <a href="{{ doc.un_url }}" target="_blank" class="text-sm text-muted hover:text-un-blue transition-colors">PDF ↗</a>
+            <a href="{{ doc.un_url }}" target="_blank" class="text-sm text-muted hover:text-un-blue transition-colors">View PDF</a>
         </div>
         
         <!-- Paragraphs -->
         <div class="divide-y divide-gray-100">
             {% for para in doc_paras %}
             <div class="px-4 py-3 flex gap-4">
-                <div class="flex-shrink-0">
-                    <a href="../documents/{{ doc.symbol|replace('/', '_') }}.html#para-{{ para.number }}" 
-                       class="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-gray-100 text-gray-700 font-medium text-sm hover:bg-un-blue hover:text-white transition-colors">
+                <div class="flex-shrink-0 text-center">
+                    <div class="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-gray-100 text-gray-700 font-medium text-sm">
                         {{ para.number }}
-                    </a>
+                    </div>
+                    <div class="mt-1">
+                        <span class="px-1.5 py-0.5 rounded text-xs font-medium
+                            {% if signal == 'agenda' %}bg-blue-100 text-blue-700
+                            {% elif signal == 'PGA' %}bg-purple-100 text-purple-700
+                            {% elif signal == 'process' %}bg-amber-100 text-amber-700
+                            {% elif signal == 'report' %}bg-green-100 text-green-700
+                            {% else %}bg-gray-100 text-gray-700{% endif %}">
+                            {{ signal }}
+                        </span>
+                    </div>
                 </div>
                 <p class="text-gray-700 leading-relaxed text-sm">{{ para.text|highlight_signals([signal]) }}</p>
             </div>

--- a/src/mandate_pipeline/templates/static/provenance.html
+++ b/src/mandate_pipeline/templates/static/provenance.html
@@ -4,12 +4,7 @@
 
 {% block nav_index %}../index.html{% endblock %}
 {% block nav_signals %}../signals.html{% endblock %}
-{% block nav_documents %}../documents/index.html{% endblock %}
-{% block nav_debug %}../debug/index.html{% endblock %}
-{% block nav_linking %}../debug/linking.html{% endblock %}
-{% block nav_orphans %}../debug/orphans.html{% endblock %}
-{% block nav_fuzzy %}../debug/fuzzy.html{% endblock %}
-{% block nav_extraction %}../debug/extraction.html{% endblock %}
+{% block nav_signals_info %}../signals-info.html{% endblock %}
 {% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
@@ -48,9 +43,9 @@
             <span class="text-sm font-medium text-gray-700">Linking Coverage:</span>
             <span class="text-sm text-muted ml-2">{{ coverage.linked }} of {{ coverage.total }} resolutions linked ({{ coverage.percentage }}%)</span>
         </div>
-        <a href="../debug/orphans.html" class="text-sm text-un-blue hover:underline">
-            View {{ coverage.unlinked }} unlinked &rarr;
-        </a>
+        <span class="text-sm text-muted">
+            {{ coverage.unlinked }} unlinked
+        </span>
     </div>
 </div>
 
@@ -83,9 +78,9 @@
         <div class="border border-gray-200 rounded-lg p-4 hover:border-gray-300 transition-colors">
             <div class="flex items-start justify-between">
                 <div class="flex-1">
-                    <a href="../documents/{{ res.filename }}" class="font-medium text-gray-900 hover:text-un-blue transition-colors">
+                    <span class="font-medium text-gray-900">
                         {{ res.symbol }}
-                    </a>
+                    </span>
                     {% if res.title %}
                     <p class="text-sm text-muted mt-1 line-clamp-1">{{ res.title }}</p>
                     {% endif %}
@@ -93,8 +88,10 @@
                 <div class="flex items-center gap-2 ml-4">
                     {% for sig, count in res.signal_summary.items() %}
                     <span class="px-1.5 py-0.5 rounded text-xs font-medium
-                        {% if 'agenda' in sig|lower %}bg-blue-50 text-blue-700
-                        {% elif 'pga' in sig|lower %}bg-purple-50 text-purple-700
+                        {% if sig == 'agenda' %}bg-blue-50 text-blue-700
+                        {% elif sig == 'PGA' %}bg-purple-50 text-purple-700
+                        {% elif sig == 'process' %}bg-amber-50 text-amber-700
+                        {% elif sig == 'report' %}bg-green-50 text-green-700
                         {% else %}bg-gray-100 text-gray-700{% endif %}">
                         {{ sig }}({{ count }})
                     </span>
@@ -113,10 +110,9 @@
                 </div>
                 <div class="flex flex-wrap gap-2">
                     {% for proposal in res.linked_proposals %}
-                    <a href="../documents/{{ proposal.filename }}"
-                       class="inline-flex items-center px-2 py-1 rounded bg-gray-50 border border-gray-200 text-xs font-medium text-gray-700 hover:border-un-blue hover:text-un-blue transition-colors">
+                    <span class="inline-flex items-center px-2 py-1 rounded bg-gray-50 border border-gray-200 text-xs font-medium text-gray-700">
                         {{ proposal.symbol }}
-                    </a>
+                    </span>
                     {% endfor %}
                 </div>
                 {% if res.linking_method %}
@@ -141,5 +137,5 @@
 {% endblock %}
 
 {% block footer %}
-Generated {{ generated_at }} · <a href="./debug/linking.html" class="text-un-blue hover:underline">Linking Debug</a>
+Generated {{ generated_at }} · <a href="../data.json" class="text-un-blue hover:underline">JSON API</a>
 {% endblock %}

--- a/src/mandate_pipeline/templates/static/signal.html
+++ b/src/mandate_pipeline/templates/static/signal.html
@@ -4,12 +4,7 @@
 
 {% block nav_index %}../index.html{% endblock %}
 {% block nav_signals %}../signals.html{% endblock %}
-{% block nav_documents %}../documents/index.html{% endblock %}
-{% block nav_debug %}../debug/index.html{% endblock %}
-{% block nav_linking %}../debug/linking.html{% endblock %}
-{% block nav_orphans %}../debug/orphans.html{% endblock %}
-{% block nav_fuzzy %}../debug/fuzzy.html{% endblock %}
-{% block nav_extraction %}../debug/extraction.html{% endblock %}
+{% block nav_signals_info %}../signals-info.html{% endblock %}
 {% block nav_api %}../data.json{% endblock %}
 
 {% block content %}
@@ -61,30 +56,19 @@
             <!-- Document Header -->
             <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100 bg-gray-50">
                 <div class="flex items-center gap-4">
-                    <a href="../documents/{{ doc.symbol|replace('/', '_') }}.html" 
-                       class="font-semibold text-lg text-gray-900 hover:text-un-blue transition-colors">
+                    <span class="font-semibold text-lg text-gray-900">
                         {{ doc.symbol }}
-                    </a>
-                    <span class="text-sm text-muted">
-                        {{ doc.signal_paragraphs|length }} match{% if doc.signal_paragraphs|length != 1 %}es{% endif %}
                     </span>
                     {% if is_adopted and doc.adopted_by %}
                     <span class="text-xs text-muted">
-                        Adopted by
-                        <a href="../documents/{{ doc.adopted_by|replace('/', '_') }}.html" class="hover:text-un-blue transition-colors">
-                            {{ doc.adopted_by }}
-                        </a>
+                        Adopted by {{ doc.adopted_by }}
                     </span>
                     {% endif %}
                 </div>
                 <div class="flex items-center gap-4">
-                    <a href="../documents/{{ doc.symbol|replace('/', '_') }}.html" 
-                       class="text-sm font-medium text-un-blue hover:text-un-blue-dark transition-colors">
-                        View document
-                    </a>
                     <a href="{{ doc.un_url }}" target="_blank"
                        class="text-sm text-muted hover:text-un-blue transition-colors">
-                        PDF ↗
+                        View PDF
                     </a>
                 </div>
             </div>
@@ -93,14 +77,26 @@
             <div class="p-5 space-y-4">
                 {% for para in doc.signal_paragraphs %}
                 <div class="flex gap-4">
-                    <a href="../documents/{{ doc.symbol|replace('/', '_') }}.html#para-{{ para.num }}"
-                       class="flex-shrink-0 inline-flex items-center justify-center w-8 h-8 rounded-lg text-sm font-bold 
-                       {% if 'agenda' in signal|lower %}bg-blue-100 text-blue-700
-                       {% elif 'pga' in signal|lower %}bg-purple-100 text-purple-700
-                       {% else %}bg-gray-100 text-gray-700{% endif %}
-                       hover:opacity-80 transition-opacity">
-                        {{ para.num }}
-                    </a>
+                    <div class="flex-shrink-0 text-center">
+                        <div class="inline-flex items-center justify-center w-8 h-8 rounded-lg text-sm font-bold
+                           {% if signal == 'agenda' %}bg-blue-100 text-blue-700
+                           {% elif signal == 'PGA' %}bg-purple-100 text-purple-700
+                           {% elif signal == 'process' %}bg-amber-100 text-amber-700
+                           {% elif signal == 'report' %}bg-green-100 text-green-700
+                           {% else %}bg-gray-100 text-gray-700{% endif %}">
+                            {{ para.num }}
+                        </div>
+                        <div class="mt-1">
+                            <span class="px-1.5 py-0.5 rounded text-xs font-medium
+                                {% if signal == 'agenda' %}bg-blue-100 text-blue-700
+                                {% elif signal == 'PGA' %}bg-purple-100 text-purple-700
+                                {% elif signal == 'process' %}bg-amber-100 text-amber-700
+                                {% elif signal == 'report' %}bg-green-100 text-green-700
+                                {% else %}bg-gray-100 text-gray-700{% endif %}">
+                                {{ signal }}
+                            </span>
+                        </div>
+                    </div>
                     <p class="text-sm text-gray-700 leading-relaxed">
                         {{ para.text|highlight_signals([signal]) }}
                     </p>

--- a/src/mandate_pipeline/templates/static/signals_info.html
+++ b/src/mandate_pipeline/templates/static/signals_info.html
@@ -1,0 +1,116 @@
+{% extends "base.html" %}
+
+{% block title %}About Signals - Mandate Pipeline{% endblock %}
+
+{% block nav_index %}./index.html{% endblock %}
+{% block nav_signals %}./signals.html{% endblock %}
+{% block nav_signals_info %}./signals-info.html{% endblock %}
+
+{% block content %}
+<!-- Header -->
+<div class="mb-8">
+    <h1 class="text-3xl font-bold text-gray-900 tracking-tight">About Signals</h1>
+    <p class="mt-2 text-muted">
+        Understanding how the Mandate Pipeline detects and categorizes signals in UN documents.
+    </p>
+</div>
+
+<!-- Overview -->
+<div class="mb-10">
+    <h2 class="text-xl font-semibold text-gray-900 mb-4">What are Signals?</h2>
+    <p class="text-gray-700 leading-relaxed mb-4">
+        Signals are specific phrases or patterns in UN General Assembly documents that indicate particular types of mandates, requests, or procedural actions. The Mandate Pipeline automatically scans operative paragraphs of resolutions and proposals to identify these signals.
+    </p>
+    <p class="text-gray-700 leading-relaxed">
+        Each signal corresponds to a category of action that the General Assembly may take, such as requesting reports, scheduling meetings, or establishing processes.
+    </p>
+</div>
+
+<!-- Signal Types -->
+<div class="mb-10">
+    <h2 class="text-xl font-semibold text-gray-900 mb-6">Signal Types</h2>
+    <div class="grid gap-6 md:grid-cols-2">
+        {% for check in checks %}
+        <div class="border rounded-lg p-5
+            {% if check.signal == 'agenda' %}border-blue-200 bg-blue-50/30
+            {% elif check.signal == 'PGA' %}border-purple-200 bg-purple-50/30
+            {% elif check.signal == 'process' %}border-amber-200 bg-amber-50/30
+            {% elif check.signal == 'report' %}border-green-200 bg-green-50/30
+            {% else %}border-gray-200 bg-gray-50/30{% endif %}">
+            <div class="flex items-center gap-2 mb-3">
+                <span class="px-2.5 py-1 rounded text-sm font-semibold
+                    {% if check.signal == 'agenda' %}bg-blue-100 text-blue-800
+                    {% elif check.signal == 'PGA' %}bg-purple-100 text-purple-800
+                    {% elif check.signal == 'process' %}bg-amber-100 text-amber-800
+                    {% elif check.signal == 'report' %}bg-green-100 text-green-800
+                    {% else %}bg-gray-100 text-gray-800{% endif %}">
+                    {{ check.signal }}
+                </span>
+            </div>
+            <p class="text-sm text-gray-600 mb-3">
+                {% if check.signal == 'agenda' %}
+                Indicates decisions about agenda items, scheduling of future consideration, or requests for inclusion in upcoming sessions.
+                {% elif check.signal == 'PGA' %}
+                References the President of the General Assembly, high-level meetings, interactive dialogues, or multistakeholder events.
+                {% elif check.signal == 'process' %}
+                Indicates procedural arrangements such as the appointment of co-facilitators, co-chairs, or informal consultations.
+                {% elif check.signal == 'report' %}
+                Requests for reports from the Secretary-General or other bodies to inform the General Assembly.
+                {% else %}
+                Miscellaneous signal type.
+                {% endif %}
+            </p>
+            <div class="mt-4">
+                <p class="text-xs font-medium text-gray-500 uppercase tracking-wide mb-2">Trigger Phrases</p>
+                <div class="flex flex-wrap gap-1.5">
+                    {% for phrase in check.phrases %}
+                    <span class="px-2 py-0.5 rounded text-xs
+                        {% if check.signal == 'agenda' %}bg-blue-100 text-blue-700
+                        {% elif check.signal == 'PGA' %}bg-purple-100 text-purple-700
+                        {% elif check.signal == 'process' %}bg-amber-100 text-amber-700
+                        {% elif check.signal == 'report' %}bg-green-100 text-green-700
+                        {% else %}bg-gray-100 text-gray-700{% endif %}">
+                        {{ phrase }}
+                    </span>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+</div>
+
+<!-- How Detection Works -->
+<div class="mb-10">
+    <h2 class="text-xl font-semibold text-gray-900 mb-4">How Detection Works</h2>
+    <div class="bg-gray-50 rounded-lg p-5 border border-gray-200">
+        <ol class="list-decimal list-inside space-y-3 text-gray-700">
+            <li><span class="font-medium">Document Processing:</span> PDF documents are parsed to extract text content.</li>
+            <li><span class="font-medium">Paragraph Extraction:</span> Operative paragraphs (numbered paragraphs in the resolution body) are identified and extracted.</li>
+            <li><span class="font-medium">Phrase Matching:</span> Each paragraph is scanned for the trigger phrases defined for each signal type.</li>
+            <li><span class="font-medium">Signal Assignment:</span> When a phrase is found, the corresponding signal is assigned to that paragraph.</li>
+            <li><span class="font-medium">Aggregation:</span> Signals are aggregated at the document level for filtering and analysis.</li>
+        </ol>
+    </div>
+</div>
+
+<!-- Configuration -->
+<div class="mb-10">
+    <h2 class="text-xl font-semibold text-gray-900 mb-4">Configuration</h2>
+    <p class="text-gray-700 leading-relaxed mb-4">
+        Signals are configured in the <code class="px-1.5 py-0.5 bg-gray-100 rounded text-sm font-mono">config/checks.yaml</code> file. Each signal definition includes:
+    </p>
+    <ul class="list-disc list-inside space-y-2 text-gray-700 mb-4">
+        <li><span class="font-medium">signal:</span> The name/identifier for the signal type</li>
+        <li><span class="font-medium">phrases:</span> A list of text patterns that trigger this signal when found in a paragraph</li>
+    </ul>
+    <p class="text-gray-700 leading-relaxed">
+        Phrase matching is case-insensitive. A paragraph can have multiple signals if it contains phrases from different signal types.
+    </p>
+</div>
+
+{% endblock %}
+
+{% block footer %}
+Generated {{ generated_at }} · <a href="./data.json" class="text-un-blue hover:underline">JSON API</a>
+{% endblock %}

--- a/src/mandate_pipeline/templates/static/signals_unified.html
+++ b/src/mandate_pipeline/templates/static/signals_unified.html
@@ -4,7 +4,7 @@
 
 {% block nav_index %}./index.html{% endblock %}
 {% block nav_signals %}./signals.html{% endblock %}
-{% block nav_documents %}./documents/index.html{% endblock %}
+{% block nav_signals_info %}./signals-info.html{% endblock %}
 
 {% block content %}
 <!-- Header -->
@@ -19,8 +19,7 @@
 <div class="mb-8 flex flex-wrap gap-4 items-end">
     <div class="flex-1 min-w-[200px]">
         <label for="source-filter" class="block text-sm font-medium text-gray-700 mb-1">Source</label>
-        <select id="source-filter" class="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent">
-            <option value="">All Sources</option>
+        <select id="source-filter" multiple class="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent" size="4">
             {% for origin_code in origin_order %}
             <option value="{{ origin_code }}">{{ origin_names.get(origin_code, origin_code) }}</option>
             {% endfor %}
@@ -28,17 +27,19 @@
     </div>
     <div class="flex-1 min-w-[200px]">
         <label for="signal-filter" class="block text-sm font-medium text-gray-700 mb-1">Signal Type</label>
-        <select id="signal-filter" class="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent">
-            <option value="">All Signals</option>
+        <select id="signal-filter" multiple class="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent" size="4">
             {% for check in checks %}
-            <option value="{{ check.signal }}">{{ check.signal }}</option>
+            <option value="{{ check.signal }}"
+                {% if check.signal == 'agenda' %}class="text-blue-700"
+                {% elif check.signal == 'PGA' %}class="text-purple-700"
+                {% elif check.signal == 'process' %}class="text-amber-700"
+                {% elif check.signal == 'report' %}class="text-green-700"{% endif %}>{{ check.signal }}</option>
             {% endfor %}
         </select>
     </div>
     <div class="flex-1 min-w-[200px]">
         <label for="doctype-filter" class="block text-sm font-medium text-gray-700 mb-1">Document Type</label>
-        <select id="doctype-filter" class="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent">
-            <option value="">All Types</option>
+        <select id="doctype-filter" multiple class="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent" size="2">
             <option value="resolution">Resolutions</option>
             <option value="proposal">Non-adopted Proposals</option>
         </select>
@@ -84,22 +85,15 @@
                                     {% else %}bg-gray-100 text-gray-700{% endif %}">
                                     {{ doc.origin[:2] }}
                                 </span>
-                                <span class="px-2 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-600">
-                                    {{ doc.signal_paragraphs|length }} paragraph{% if doc.signal_paragraphs|length != 1 %}s{% endif %}
-                                </span>
                             </div>
                             {% if doc.title %}
                             <p class="text-sm text-gray-600 truncate" title="{{ doc.title }}">{{ doc.title }}</p>
                             {% endif %}
                         </div>
                         <div class="flex items-center gap-2 flex-shrink-0">
-                            <a href="./documents/{{ doc.symbol|replace('/', '_') }}.html"
-                               class="text-xs text-muted hover:text-un-blue transition-colors">
-                                Details
-                            </a>
                             <a href="{{ doc.un_url }}" target="_blank"
                                class="text-xs text-muted hover:text-un-blue transition-colors">
-                                PDF
+                                View PDF
                             </a>
                         </div>
                     </div>
@@ -109,23 +103,24 @@
                 <div class="divide-y divide-gray-100">
                     {% for para in doc.signal_paragraphs %}
                     <div class="px-4 py-3 flex gap-4 paragraph-item" data-signals="{{ para.signals|join(',') }}">
-                        <div class="flex-shrink-0">
-                            <a href="./documents/{{ doc.symbol|replace('/', '_') }}.html#para-{{ para.number }}"
-                               class="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-gray-100 text-gray-700 font-medium text-sm hover:bg-un-blue hover:text-white transition-colors">
+                        <div class="flex-shrink-0 text-center">
+                            <div class="inline-flex items-center justify-center w-8 h-8 rounded-lg bg-gray-100 text-gray-700 font-medium text-sm">
                                 {{ para.number }}
-                            </a>
-                        </div>
-                        <div class="flex-1 min-w-0">
-                            <div class="flex flex-wrap gap-1 mb-2">
+                            </div>
+                            <div class="flex flex-col gap-1 mt-2">
                                 {% for signal in para.signals %}
-                                <span class="px-2 py-0.5 rounded text-xs font-medium signal-tag
-                                    {% if 'agenda' in signal|lower %}bg-blue-50 text-blue-700
-                                    {% elif 'pga' in signal|lower %}bg-purple-50 text-purple-700
+                                <span class="px-1.5 py-0.5 rounded text-xs font-medium signal-tag
+                                    {% if signal == 'agenda' %}bg-blue-100 text-blue-700
+                                    {% elif signal == 'PGA' %}bg-purple-100 text-purple-700
+                                    {% elif signal == 'process' %}bg-amber-100 text-amber-700
+                                    {% elif signal == 'report' %}bg-green-100 text-green-700
                                     {% else %}bg-gray-100 text-gray-600{% endif %}">
                                     {{ signal }}
                                 </span>
                                 {% endfor %}
                             </div>
+                        </div>
+                        <div class="flex-1 min-w-0">
                             <p class="text-gray-700 leading-relaxed text-sm">{{ para.text|highlight_signals(para.signals) }}</p>
                         </div>
                     </div>
@@ -157,16 +152,31 @@ document.addEventListener('DOMContentLoaded', function() {
     const emptyState = document.getElementById('empty-state');
     const statsText = document.getElementById('stats-text');
 
+    // Get selected values from multiselect
+    function getSelectedValues(selectElement) {
+        return Array.from(selectElement.selectedOptions).map(opt => opt.value);
+    }
+
     // Parse URL params and set initial filter state
     function initFromUrl() {
         const params = new URLSearchParams(window.location.search);
-        const source = params.get('source');
-        const signal = params.get('signal');
-        const doctype = params.get('type');
+        const sources = params.getAll('source');
+        const signals = params.getAll('signal');
+        const doctypes = params.getAll('type');
 
-        if (source) sourceFilter.value = source;
-        if (signal) signalFilter.value = signal;
-        if (doctype) doctypeFilter.value = doctype;
+        // Set multiselect values
+        sources.forEach(source => {
+            const opt = sourceFilter.querySelector(`option[value="${source}"]`);
+            if (opt) opt.selected = true;
+        });
+        signals.forEach(signal => {
+            const opt = signalFilter.querySelector(`option[value="${signal}"]`);
+            if (opt) opt.selected = true;
+        });
+        doctypes.forEach(doctype => {
+            const opt = doctypeFilter.querySelector(`option[value="${doctype}"]`);
+            if (opt) opt.selected = true;
+        });
 
         applyFilters();
     }
@@ -174,9 +184,9 @@ document.addEventListener('DOMContentLoaded', function() {
     // Update URL without reloading
     function updateUrl() {
         const params = new URLSearchParams();
-        if (sourceFilter.value) params.set('source', sourceFilter.value);
-        if (signalFilter.value) params.set('signal', signalFilter.value);
-        if (doctypeFilter.value) params.set('type', doctypeFilter.value);
+        getSelectedValues(sourceFilter).forEach(v => params.append('source', v));
+        getSelectedValues(signalFilter).forEach(v => params.append('signal', v));
+        getSelectedValues(doctypeFilter).forEach(v => params.append('type', v));
 
         const newUrl = params.toString()
             ? `${window.location.pathname}?${params.toString()}`
@@ -185,9 +195,9 @@ document.addEventListener('DOMContentLoaded', function() {
     }
 
     function applyFilters() {
-        const selectedSource = sourceFilter.value;
-        const selectedSignal = signalFilter.value;
-        const selectedDoctype = doctypeFilter.value;
+        const selectedSources = getSelectedValues(sourceFilter);
+        const selectedSignals = getSelectedValues(signalFilter);
+        const selectedDoctypes = getSelectedValues(doctypeFilter);
         let resolutionCount = 0;
         let proposalCount = 0;
         let paragraphCount = 0;
@@ -197,14 +207,14 @@ document.addEventListener('DOMContentLoaded', function() {
             const cardDoctype = card.dataset.doctype;
             const cardSignals = card.dataset.signals.split(',').filter(s => s);
 
-            // Check source filter
-            const sourceMatch = !selectedSource || cardSource === selectedSource;
+            // Check source filter (match any selected)
+            const sourceMatch = selectedSources.length === 0 || selectedSources.includes(cardSource);
 
-            // Check signal filter
-            const signalMatch = !selectedSignal || cardSignals.includes(selectedSignal);
+            // Check signal filter (match any selected)
+            const signalMatch = selectedSignals.length === 0 || selectedSignals.some(s => cardSignals.includes(s));
 
-            // Check document type filter
-            const doctypeMatch = !selectedDoctype || cardDoctype === selectedDoctype;
+            // Check document type filter (match any selected)
+            const doctypeMatch = selectedDoctypes.length === 0 || selectedDoctypes.includes(cardDoctype);
 
             if (sourceMatch && signalMatch && doctypeMatch) {
                 card.classList.remove('hidden');
@@ -218,7 +228,7 @@ document.addEventListener('DOMContentLoaded', function() {
                 const paragraphs = card.querySelectorAll('.paragraph-item');
                 paragraphs.forEach(para => {
                     const paraSignals = para.dataset.signals.split(',').filter(s => s);
-                    if (!selectedSignal || paraSignals.includes(selectedSignal)) {
+                    if (selectedSignals.length === 0 || selectedSignals.some(s => paraSignals.includes(s))) {
                         para.classList.remove('hidden');
                         paragraphCount++;
                     } else {
@@ -241,7 +251,6 @@ document.addEventListener('DOMContentLoaded', function() {
         }
 
         // Update stats
-        let statsStr = `${paragraphCount} paragraphs across `;
         const parts = [];
         if (resolutionCount > 0) {
             parts.push(`${resolutionCount} resolution${resolutionCount !== 1 ? 's' : ''}`);
@@ -249,7 +258,7 @@ document.addEventListener('DOMContentLoaded', function() {
         if (proposalCount > 0) {
             parts.push(`${proposalCount} non-adopted proposal${proposalCount !== 1 ? 's' : ''}`);
         }
-        statsText.textContent = statsStr + (parts.length > 0 ? parts.join(' and ') : '0 documents');
+        statsText.textContent = parts.length > 0 ? parts.join(' and ') : '0 documents';
 
         updateUrl();
     }
@@ -260,9 +269,10 @@ document.addEventListener('DOMContentLoaded', function() {
     doctypeFilter.addEventListener('change', applyFilters);
 
     clearFiltersBtn.addEventListener('click', function() {
-        sourceFilter.value = '';
-        signalFilter.value = '';
-        doctypeFilter.value = '';
+        // Deselect all options in multiselects
+        Array.from(sourceFilter.options).forEach(opt => opt.selected = false);
+        Array.from(signalFilter.options).forEach(opt => opt.selected = false);
+        Array.from(doctypeFilter.options).forEach(opt => opt.selected = false);
         applyFilters();
     });
 


### PR DESCRIPTION
## Summary
This PR significantly simplifies the Mandate Pipeline UI by removing individual document pages and debug features, while adding a new "About Signals" informational page. The changes streamline the navigation and focus the interface on signal browsing and analysis.

## Key Changes

### Removed Features
- **Document pages**: Removed generation of individual document detail pages (`generate_documents_list_page`, `generate_document_page`)
- **Debug pages**: Removed all debug functionality including linking audit, orphans, fuzzy matches, and extraction pages (`generate_debug_pages`)
- **Fuzzy matching**: Removed the fuzzy title matching pass (Pass 2) from the document linking logic that used `rapidfuzz`
- **Removed imports**: Cleaned up unused imports (`get_linking_audit`, `get_undl_cache_stats`, `normalize_title`, `rapidfuzz`)

### Added Features
- **Signals info page**: New `generate_signals_info_page()` function that creates an informational page explaining what signals are, how they work, and how they're configured
- **Signal color definitions**: Centralized signal color scheme (agenda=blue, PGA=purple, process=amber, report=green) for consistency across pages

### Navigation Updates
- Simplified top navigation bar: removed "Documents" and "Debug" menu items
- Updated navigation to include "Browser" (signals) and "About Signals" links
- Removed all debug-related navigation blocks from templates

### Template Updates
- Updated all templates to remove links to document pages and debug pages
- Simplified document references to plain text instead of clickable links
- Improved signal color consistency using exact signal name matching instead of substring matching
- Removed document adoption links and simplified related UI elements
- Updated footer links to point to JSON API instead of debug pages

### Code Cleanup
- Removed `normalize_title()` function from linking.py (was only used for fuzzy matching)
- Removed fuzzy matching logic that attempted to link proposals to resolutions based on title similarity
- Removed directory creation for `/documents` and `/debug` folders

## Implementation Details
- The new signals info page is generated at `signals-info.html` and provides user-facing documentation about signal types and detection methodology
- Signal colors are now defined in a consistent dictionary structure passed to templates
- All template color logic updated to use exact signal name matching (e.g., `check.signal == 'agenda'`) for better maintainability
- The linking audit and fuzzy matching removal simplifies the document linking process to rely only on explicit metadata and direct symbol matching