### PR TITLE
Add title normalization function for fuzzy matching

### DIFF
--- a/src/mandate_pipeline/generation.py
+++ b/src/mandate_pipeline/generation.py
@@ -27,6 +27,7 @@ from .linking import (
     symbol_to_filename,
     derive_resolution_origin,
     derive_origin_from_symbol,
+    normalize_title,
     COMMITTEE_NAMES,
 )
 

--- a/src/mandate_pipeline/linking.py
+++ b/src/mandate_pipeline/linking.py
@@ -223,6 +223,9 @@ def normalize_symbol(symbol: str) -> str:
     return symbol.strip().upper()
 
 
+def normalize_title(title: str) -> str:
+    """Normalize a document title for fuzzy matching."""
+    return title.strip().lower()
 
 
 def is_resolution(symbol: str) -> bool:


### PR DESCRIPTION
## Summary
Added a new `normalize_title()` function to standardize document titles for fuzzy matching operations, improving consistency in title comparison across the mandate pipeline.

## Changes
- **New function**: `normalize_title()` in `linking.py` that strips whitespace and converts titles to lowercase for consistent comparison
- **Export**: Added `normalize_title` to the imports in `generation.py` to make it available across the pipeline

## Implementation Details
The `normalize_title()` function follows the same pattern as the existing `normalize_symbol()` function, providing a simple but effective normalization strategy:
- Strips leading/trailing whitespace
- Converts to lowercase for case-insensitive matching

This enables more reliable fuzzy matching of document titles by reducing false negatives caused by whitespace variations and case differences.