### PR TITLE
Add AGENTS.md and ensure `docs/` remains tracked

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,8 @@
+# Agent Instructions
+
+The `docs/` directory contains generated static site output used by the pipeline. It **must remain tracked** in git because the pipeline expects it to exist in the repository.
+
+When making code changes:
+- Do **not** edit files under `docs/` unless the user explicitly asks for a regeneration.
+- Avoid staging or committing `docs/` changes that are incidental to code edits (e.g., from running the generator locally).
+- Keep changes focused on the source code and templates that *produce* the static site output.


### PR DESCRIPTION
### Motivation
- The pipeline expects the generated `docs/` directory to be present in the repository, and untracking it would break pipeline execution.
- Provide explicit agent guidance so contributors and automation avoid accidental edits or commits to generated output.

### Description
- Add `AGENTS.md` containing instructions that `docs/` must remain tracked and guidance to avoid incidental edits or commits to generated output.
- Remove the `docs/` ignore rule from `.gitignore` so the generated site remains in source control.
- Update `README.md` to reflect that `docs/` is the generated static website in the project layout.

### Testing
- No automated tests were run because these are documentation-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697377d9bc7c832e97c9ddc45f29602a)