### PR TITLE
ci: record discovery run metadata

### DIFF
--- a/.github/workflows/discover.yml
+++ b/.github/workflows/discover.yml
@@ -33,6 +33,22 @@ jobs:
       - name: Discover new documents
         run: python -m mandate_pipeline.cli discover --config ./config --data ./data
 
+      - name: Record discovery run metadata
+        if: always()
+        run: |
+          cat > data/last_discover_run.json << 'EOF'
+          {
+            "run_id": "${{ github.run_id }}",
+            "run_attempt": "${{ github.run_attempt }}",
+            "event_name": "${{ github.event_name }}",
+            "ref": "${{ github.ref }}",
+            "ref_name": "${{ github.ref_name }}",
+            "sha": "${{ github.sha }}",
+            "actor": "${{ github.actor }}",
+            "timestamp_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+
       - name: Check for changes
         id: changes
         run: |

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Complete metadata export for external tools:
 
 Two workflows automate the pipeline:
 
-### fetch-documents.yml
+### discover.yml
 
 - **Trigger**: Daily at 6 AM UTC or manual
 - **Action**: Run `mandate discover`, commit new PDFs
@@ -359,7 +359,7 @@ Two workflows automate the pipeline:
 ```
 Schedule (6 AM UTC)
     ↓
-fetch-documents.yml
+discover.yml
     ↓ (on success)
 linkage-analysis.yml
     ↓ (triggers)


### PR DESCRIPTION
### Motivation
- Persist per-run metadata from the discovery workflow so scheduled vs manual runs can be diagnosed when automatic runs appear not to trigger.

### Description
- Add a step to ` .github/workflows/discover.yml` that always writes a JSON file `data/last_discover_run.json` containing `run_id`, `run_attempt`, `event_name`, `ref`, `ref_name`, `sha`, `actor`, and `timestamp_utc` after the discovery step.

### Testing
- No automated tests were run because this is a workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69739de0a614832ea9b461f7a66f620e)