### PR TITLE
Align signals browser multiselects and inline signal tags

### DIFF
--- a/src/mandate_pipeline/templates/static/signals_unified.html
+++ b/src/mandate_pipeline/templates/static/signals_unified.html
@@ -18,16 +18,16 @@
 <!-- Filter Controls -->
 <div class="mb-8 flex flex-wrap gap-4 items-end">
     <div class="flex-1 min-w-[200px]">
-        <label for="source-filter" class="block text-sm font-medium text-gray-700 mb-1">Source</label>
-        <select id="source-filter" multiple class="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent" size="4">
+        <label for="source-filter" class="inline-flex items-center text-xs font-semibold uppercase tracking-wide text-gray-500">Source</label>
+        <select id="source-filter" multiple class="mt-2 w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent" size="4">
             {% for origin_code in origin_order %}
             <option value="{{ origin_code }}">{{ origin_names.get(origin_code, origin_code) }}</option>
             {% endfor %}
         </select>
     </div>
     <div class="flex-1 min-w-[200px]">
-        <label for="signal-filter" class="block text-sm font-medium text-gray-700 mb-1">Signal Type</label>
-        <select id="signal-filter" multiple class="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent" size="4">
+        <label for="signal-filter" class="inline-flex items-center text-xs font-semibold uppercase tracking-wide text-gray-500">Signal Type</label>
+        <select id="signal-filter" multiple class="mt-2 w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent" size="4">
             {% for check in checks %}
             <option value="{{ check.signal }}"
                 {% if check.signal == 'agenda' %}class="text-blue-700"
@@ -38,8 +38,8 @@
         </select>
     </div>
     <div class="flex-1 min-w-[200px]">
-        <label for="doctype-filter" class="block text-sm font-medium text-gray-700 mb-1">Document Type</label>
-        <select id="doctype-filter" multiple class="w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent" size="2">
+        <label for="doctype-filter" class="inline-flex items-center text-xs font-semibold uppercase tracking-wide text-gray-500">Document Type</label>
+        <select id="doctype-filter" multiple class="mt-2 w-full px-3 py-2 border border-gray-300 rounded-lg bg-white text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-un-blue focus:border-transparent" size="2">
             <option value="resolution">Resolutions</option>
             <option value="proposal">Non-adopted Proposals</option>
         </select>
@@ -102,11 +102,11 @@
                 <!-- Paragraphs -->
                 <div class="divide-y divide-gray-100">
                     {% for para in doc.signal_paragraphs %}
-                    <div class="px-4 py-3 flex gap-4 paragraph-item" data-signals="{{ para.signals|join(',') }}">
-                        <div class="flex-shrink-0 text-center">
-                            <div class="flex flex-col gap-1">
+                    <div class="px-4 py-3 paragraph-item" data-signals="{{ para.signals|join(',') }}">
+                        <p class="text-gray-700 leading-relaxed text-sm flex flex-wrap items-baseline gap-2">
+                            <span class="flex flex-wrap gap-1.5">
                                 {% for signal in para.signals %}
-                                <span class="px-1.5 py-0.5 rounded text-xs font-medium signal-tag inline-flex items-center justify-center w-24 text-center
+                                <span class="px-2 py-0.5 rounded text-xs font-medium signal-tag inline-flex items-center justify-center
                                     {% if signal == 'agenda' %}bg-blue-100 text-blue-700
                                     {% elif signal == 'PGA' %}bg-purple-100 text-purple-700
                                     {% elif signal == 'process' %}bg-amber-100 text-amber-700
@@ -115,14 +115,10 @@
                                     {{ signal }}
                                 </span>
                                 {% endfor %}
-                            </div>
-                        </div>
-                        <div class="flex-1 min-w-0">
-                            <p class="text-gray-700 leading-relaxed text-sm">
-                                <span class="font-medium text-gray-700 mr-1">{{ para.number }}.</span>
-                                {{ para.text|highlight_signals(para.signals) }}
-                            </p>
-                        </div>
+                            </span>
+                            <span class="font-medium text-gray-700">{{ para.number }}.</span>
+                            <span class="min-w-0">{{ para.text|highlight_signals(para.signals) }}</span>
+                        </p>
                     </div>
                     {% endfor %}
                 </div>


### PR DESCRIPTION
### Motivation
- Improve the visual consistency of the Signals browser controls so the multiselect labels match the rest of the UI typography and spacing.
- Reduce excess whitespace around paragraph signal labels and present them inline with paragraph numbers for a denser, cleaner layout.
- Make signal tags visually consistent with other label styles used across the interface.

### Description
- Updated `src/mandate_pipeline/templates/static/signals_unified.html` to use `inline-flex` label styles, uppercase `text-xs` typography, `mt-2` spacing and `shadow-sm` on select inputs for the filter controls.
- Reworked paragraph markup to render signal tags inline with the paragraph number and text, replacing the old two-column tag layout with a single `flex` line that places tags before the paragraph number.
- Adjusted tag classes (padding/size) to remove fixed width and tighten spacing so labels match existing color/typography schemes.

### Testing
- Rendered the updated `signals_unified.html` template with a small sample dataset using Jinja2, and the template rendered successfully to `signals.html` (success).
- Launched a temporary static server and captured a visual preview screenshot using Playwright to validate the UI change, and the screenshot generation completed successfully (success).
- No unit test changes were required since this is a visual/template-only update (no automated unit tests were run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b0ff8858832e86b8b1a374dbd971)