### PR TITLE
Generate markdown-only signal reports (disable email delivery)

### DIFF
--- a/.github/workflows/email-signals.yml
+++ b/.github/workflows/email-signals.yml
@@ -38,21 +38,9 @@ jobs:
       - name: Run pipeline
         run: python -m mandate_pipeline.cli build --config ./config --data ./data --output ./docs --skip-debug
 
-      - name: Send signal email reports
+      - name: Generate signal markdown reports
         env:
-          MAILGUN_API_KEY: ${{ secrets.MAILGUN_API_KEY }}
-          MAILGUN_DOMAIN: ${{ secrets.MAILGUN_DOMAIN }}
-          MAILGUN_FROM: ${{ secrets.MAILGUN_FROM }}
-          MAILGUN_BASE_URL: ${{ secrets.MAILGUN_BASE_URL }}
-          SMTP_HOST: ${{ secrets.SMTP_HOST }}
-          SMTP_PORT: ${{ secrets.SMTP_PORT }}
-          SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
-          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
-          SMTP_FROM: ${{ secrets.SMTP_FROM }}
-          SMTP_USE_SSL: ${{ secrets.SMTP_USE_SSL }}
-          SMTP_STARTTLS: ${{ secrets.SMTP_STARTTLS }}
           SIGNAL_EMAIL_RECIPIENTS: ${{ secrets.SIGNAL_EMAIL_RECIPIENTS }}
-          EMAIL_REPORT_DRY_RUN: ${{ github.event_name == 'workflow_dispatch' }}
           EMAIL_REPORT_PREVIEW_DIR: ./email-previews
         run: |
           if [ -f /tmp/previous-data.json ]; then
@@ -62,7 +50,6 @@ jobs:
           fi
 
       - name: Upload email previews
-        if: ${{ github.event_name == 'workflow_dispatch' }}
         uses: actions/upload-artifact@v4
         with:
           name: email-previews

--- a/README.md
+++ b/README.md
@@ -197,42 +197,22 @@ checks:
 ## Email Signal Reports (GitHub Actions)
 
 The `Email Signal Reports` workflow (`.github/workflows/email-signals.yml`) can run daily to
-execute the pipeline and send one email per signal. Each email includes all resolutions for
-that signal, with newly discovered resolutions listed first and bolded.
-
-Manual runs (`workflow_dispatch`) default to a **dry run** that does not send email. Instead,
-the workflow writes email previews to `./email-previews`, uploads them as a workflow artifact,
-and lists the preview filenames in the GitHub Actions job summary.
+execute the pipeline and generate one markdown report per signal. Each report includes all
+resolutions for that signal, with newly discovered resolutions listed first and bolded. The
+workflow writes markdown previews to `./email-previews`, uploads them as a workflow artifact,
+and lists the preview filenames plus an inlined markdown summary in the GitHub Actions job
+summary.
 
 ### Required GitHub Secrets
 
-Configure the SMTP or Mailgun secrets in your repository settings, plus recipients:
-
-**Mailgun (optional, preferred if configured)**
-
-- `MAILGUN_API_KEY`: Mailgun API key
-- `MAILGUN_DOMAIN`: Mailgun sending domain
-- `MAILGUN_FROM`: From address (defaults to `SMTP_FROM` if omitted)
-- `MAILGUN_BASE_URL`: Override API base URL (e.g., `https://api.eu.mailgun.net/v3`) (optional)
-
-**SMTP (fallback if Mailgun is not configured)**
-
-- `SMTP_HOST`: SMTP server hostname
-- `SMTP_PORT`: SMTP server port (default 587)
-- `SMTP_USERNAME`: SMTP username (optional if server allows unauthenticated sends)
-- `SMTP_PASSWORD`: SMTP password
-- `SMTP_FROM`: From address (e.g., `mandate-bot@example.com`)
-- `SMTP_USE_SSL`: `true` if you need implicit SSL (optional)
-- `SMTP_STARTTLS`: `true` to use STARTTLS on standard ports (optional)
-
 **Recipients**
 
-- `SIGNAL_EMAIL_RECIPIENTS`: JSON mapping of signals to recipient lists
+- `SIGNAL_EMAIL_RECIPIENTS`: JSON mapping of signals to recipient lists (optional; if omitted,
+  all signals are included)
 
-### Manual dry-run behavior
+### Optional behavior
 
-To override the default dry-run behavior, set `EMAIL_REPORT_DRY_RUN=false` in the workflow
-environment. You can also set `EMAIL_REPORT_PREVIEW_DIR` to change where previews are written.
+Set `EMAIL_REPORT_PREVIEW_DIR` to change where previews are written.
 
 Example `SIGNAL_EMAIL_RECIPIENTS` secret:
 

--- a/src/mandate_pipeline/email_report.py
+++ b/src/mandate_pipeline/email_report.py
@@ -1,40 +1,11 @@
-"""Generate and send per-signal email reports from pipeline output."""
+"""Generate per-signal email markdown reports from pipeline output."""
 
 import argparse
 import json
 import os
-import smtplib
 from datetime import datetime, timezone
-from dataclasses import dataclass
-from email.message import EmailMessage
 from pathlib import Path
-from typing import Iterable, Optional
-
-import requests
-
-
-@dataclass(frozen=True)
-class SmtpConfig:
-    host: str
-    port: int
-    username: Optional[str]
-    password: Optional[str]
-    sender: str
-    use_ssl: bool
-    starttls: bool
-
-
-@dataclass(frozen=True)
-class MailgunConfig:
-    api_key: str
-    domain: str
-    sender: str
-    base_url: str
-
-
-def is_truthy(value: Optional[str]) -> bool:
-    """Return True for common truthy strings."""
-    return (value or "").strip().lower() in {"1", "true", "yes", "y"}
+from typing import Optional
 
 
 def sanitize_filename(value: str) -> str:
@@ -47,8 +18,7 @@ def write_email_preview(
     output_dir: Path,
     signal: str,
     subject: str,
-    html_body: str,
-    text_body: str,
+    markdown_body: str,
 ) -> Path:
     """Write an email preview file to disk."""
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -60,18 +30,7 @@ def write_email_preview(
             [
                 f"# {subject}",
                 "",
-                "## Text",
-                "",
-                "```",
-                text_body,
-                "```",
-                "",
-                "## HTML",
-                "",
-                "```html",
-                html_body,
-                "```",
-                "",
+                markdown_body,
             ]
         ),
         encoding="utf-8",
@@ -79,16 +38,25 @@ def write_email_preview(
     return preview_path
 
 
-def append_summary_entry(signal: str, subject: str, preview_path: Optional[Path]) -> None:
+def append_summary_entry(
+    signal: str,
+    subject: str,
+    preview_path: Optional[Path],
+    markdown_body: Optional[str],
+) -> None:
     """Append a link to the GitHub Actions summary, if available."""
     summary_file = os.getenv("GITHUB_STEP_SUMMARY")
     if not summary_file:
         return
     with open(summary_file, "a", encoding="utf-8") as handle:
-        handle.write(f"- **{signal}**: {subject}")
+        handle.write(f"## {signal}\n\n")
+        handle.write(f"**{subject}**\n\n")
         if preview_path:
-            handle.write(f" (preview: `{preview_path}`)")
-        handle.write("\n")
+            handle.write(f"Preview: `{preview_path}`\n\n")
+        if markdown_body:
+            handle.write("<details>\n<summary>Markdown report</summary>\n\n")
+            handle.write(markdown_body)
+            handle.write("\n\n</details>\n\n")
 
 
 def load_data(path: Path) -> dict:
@@ -142,28 +110,42 @@ def collect_symbols_by_signal(grouped: dict[str, list[dict]]) -> dict[str, set[s
     }
 
 
-def build_email(
+def format_paragraphs_markdown(paragraphs: dict) -> list[str]:
+    """Format numbered paragraphs for markdown output."""
+    if not paragraphs:
+        return ["_No operative paragraphs found._"]
+    keys = list(paragraphs.keys())
+
+    def sort_key(value: object) -> tuple[int, str]:
+        try:
+            return (0, f"{int(value):06d}")
+        except (TypeError, ValueError):
+            return (1, str(value))
+
+    lines = []
+    for key in sorted(keys, key=sort_key):
+        text = paragraphs.get(key)
+        if text:
+            lines.append(f"- **{key}.** {text}")
+    return lines or ["_No operative paragraphs found._"]
+
+
+def build_email_markdown(
     signal: str,
     docs: list[dict],
     new_symbols: set[str],
     generated_at: str,
-) -> tuple[str, str, str]:
-    """Build subject, HTML body, and text body for an email."""
+) -> tuple[str, str]:
+    """Build subject and markdown body for an email-ready report."""
     new_docs = [doc for doc in docs if doc.get("symbol") in new_symbols]
     old_docs = [doc for doc in docs if doc.get("symbol") not in new_symbols]
     ordered_docs = new_docs + old_docs
 
     subject = f"Mandate Pipeline: {signal} ({len(new_docs)} new)"
 
-    html_lines = [
-        f"<h2>Signal: {signal}</h2>",
-        f"<p>Generated at {generated_at}.</p>",
-        "<ul>",
-    ]
-
-    text_lines = [
-        f"Signal: {signal}",
-        f"Generated at {generated_at}",
+    markdown_lines = [
+        f"Signal: **{signal}**",
+        f"Generated at {generated_at}.",
         "",
     ]
 
@@ -171,133 +153,26 @@ def build_email(
         symbol = doc.get("symbol", "Unknown symbol")
         title = doc.get("title") or "Untitled"
         url = doc.get("un_url") or ""
-        line_text = f"- {symbol} — {title}"
-        if url:
-            line_text += f" ({url})"
-
         if doc.get("symbol") in new_symbols:
-            html_lines.append(
-                f"  <li><strong>{symbol} — {title}</strong>"
-                f"{f' (<a href=\"{url}\">link</a>)' if url else ''}</li>"
-            )
-            text_lines.append(f"*NEW* {line_text}")
+            markdown_lines.append(f"## {symbol} — {title} (**NEW**)")
         else:
-            html_lines.append(
-                f"  <li>{symbol} — {title}"
-                f"{f' (<a href=\"{url}\">link</a>)' if url else ''}</li>"
-            )
-            text_lines.append(line_text)
-
-    html_lines.append("</ul>")
+            markdown_lines.append(f"## {symbol} — {title}")
+        if url:
+            markdown_lines.append(f"- UN ODS: {url}")
+        markdown_lines.append("- Resolution text (operative paragraphs):")
+        markdown_lines.extend(format_paragraphs_markdown(doc.get("paragraphs", {})))
+        markdown_lines.append("")
 
     if not ordered_docs:
-        html_lines.append("<p>No resolutions found for this signal.</p>")
-        text_lines.append("No resolutions found for this signal.")
+        markdown_lines.append("No resolutions found for this signal.")
 
-    html_body = "\n".join(html_lines)
-    text_body = "\n".join(text_lines)
-    return subject, html_body, text_body
-
-
-def send_email(
-    smtp_config: SmtpConfig,
-    recipients: Iterable[str],
-    subject: str,
-    html_body: str,
-    text_body: str,
-) -> None:
-    """Send an email using SMTP."""
-    message = EmailMessage()
-    message["Subject"] = subject
-    message["From"] = smtp_config.sender
-    message["To"] = ", ".join(recipients)
-    message.set_content(text_body)
-    message.add_alternative(html_body, subtype="html")
-
-    if smtp_config.use_ssl:
-        server = smtplib.SMTP_SSL(smtp_config.host, smtp_config.port)
-    else:
-        server = smtplib.SMTP(smtp_config.host, smtp_config.port)
-
-    try:
-        if smtp_config.starttls and not smtp_config.use_ssl:
-            server.starttls()
-        if smtp_config.username and smtp_config.password:
-            server.login(smtp_config.username, smtp_config.password)
-        server.send_message(message)
-    finally:
-        server.quit()
-
-
-def send_mailgun_email(
-    mailgun_config: MailgunConfig,
-    recipients: Iterable[str],
-    subject: str,
-    html_body: str,
-    text_body: str,
-) -> None:
-    """Send an email using the Mailgun API."""
-    url = f"{mailgun_config.base_url}/{mailgun_config.domain}/messages"
-    response = requests.post(
-        url,
-        auth=("api", mailgun_config.api_key),
-        data={
-            "from": mailgun_config.sender,
-            "to": ", ".join(recipients),
-            "subject": subject,
-            "text": text_body,
-            "html": html_body,
-        },
-        timeout=30,
-    )
-    response.raise_for_status()
-
-
-def load_mailgun_config() -> Optional[MailgunConfig]:
-    """Load Mailgun configuration from environment variables."""
-    api_key = os.getenv("MAILGUN_API_KEY")
-    domain = os.getenv("MAILGUN_DOMAIN")
-    sender = os.getenv("MAILGUN_FROM") or os.getenv("SMTP_FROM")
-    if not api_key or not domain:
-        return None
-    if not sender:
-        raise ValueError("MAILGUN_FROM or SMTP_FROM must be set for Mailgun")
-    base_url = os.getenv("MAILGUN_BASE_URL", "https://api.mailgun.net/v3")
-    return MailgunConfig(
-        api_key=api_key,
-        domain=domain,
-        sender=sender,
-        base_url=base_url,
-    )
-
-
-def load_smtp_config() -> SmtpConfig:
-    """Load SMTP configuration from environment variables."""
-    host = os.getenv("SMTP_HOST")
-    sender = os.getenv("SMTP_FROM")
-    if not host or not sender:
-        raise ValueError("SMTP_HOST and SMTP_FROM must be set for SMTP delivery")
-
-    port = int(os.getenv("SMTP_PORT", "587"))
-    username = os.getenv("SMTP_USERNAME")
-    password = os.getenv("SMTP_PASSWORD")
-    use_ssl = os.getenv("SMTP_USE_SSL", "false").lower() in {"1", "true", "yes"}
-    starttls = os.getenv("SMTP_STARTTLS", "true").lower() in {"1", "true", "yes"}
-
-    return SmtpConfig(
-        host=host,
-        port=port,
-        username=username,
-        password=password,
-        sender=sender,
-        use_ssl=use_ssl,
-        starttls=starttls,
-    )
+    markdown_body = "\n".join(markdown_lines).strip()
+    return subject, markdown_body
 
 
 def main() -> None:
     """CLI entrypoint."""
-    parser = argparse.ArgumentParser(description="Send per-signal email reports.")
+    parser = argparse.ArgumentParser(description="Generate per-signal email markdown reports.")
     parser.add_argument(
         "--current",
         type=Path,
@@ -316,21 +191,10 @@ def main() -> None:
         required=False,
         help="Directory to write email previews (default: ./email-previews)",
     )
-    parser.add_argument(
-        "--dry-run",
-        action="store_true",
-        help="Generate email previews instead of sending email.",
-    )
     args = parser.parse_args()
 
     recipients_raw = os.getenv("SIGNAL_EMAIL_RECIPIENTS")
-    if not recipients_raw:
-        raise ValueError("SIGNAL_EMAIL_RECIPIENTS must be set")
-
-    recipients_map = parse_recipients(recipients_raw)
-    mailgun_config = load_mailgun_config()
-    smtp_config = None if mailgun_config else load_smtp_config()
-    dry_run = args.dry_run or is_truthy(os.getenv("EMAIL_REPORT_DRY_RUN"))
+    recipients_map = parse_recipients(recipients_raw) if recipients_raw else {}
     preview_dir = args.preview_dir or Path(os.getenv("EMAIL_REPORT_PREVIEW_DIR", "./email-previews"))
 
     current_data = load_data(args.current)
@@ -345,31 +209,25 @@ def main() -> None:
 
     generated_at = current_data.get("generated_at", "unknown time")
 
-    if dry_run:
-        append_summary_entry("Summary", f"Dry run enabled; previews in {preview_dir}", None)
+    append_summary_entry(
+        "Summary",
+        f"Markdown previews written to {preview_dir}",
+        None,
+        None,
+    )
 
     for signal, docs in current_grouped.items():
-        recipients = recipients_map.get(signal) or recipients_map.get("default", [])
-        if not recipients:
-            print(f"Skipping signal '{signal}': no recipients configured")
-            continue
+        if recipients_map:
+            recipients = recipients_map.get(signal) or recipients_map.get("default", [])
+            if not recipients:
+                print(f"Skipping signal '{signal}': no recipients configured")
+                continue
 
         new_symbols = current_symbols.get(signal, set()) - previous_symbols.get(signal, set())
-        subject, html_body, text_body = build_email(signal, docs, new_symbols, generated_at)
-        if dry_run:
-            preview_path = write_email_preview(preview_dir, signal, subject, html_body, text_body)
-            append_summary_entry(signal, subject, preview_path)
-            print(f"Dry run: wrote {preview_path}")
-            continue
-
-        if mailgun_config:
-            send_mailgun_email(mailgun_config, recipients, subject, html_body, text_body)
-        else:
-            if smtp_config is None:
-                raise ValueError("SMTP configuration is missing")
-            send_email(smtp_config, recipients, subject, html_body, text_body)
-        append_summary_entry(signal, subject, None)
-        print(f"Sent {signal} report to {', '.join(recipients)}")
+        subject, markdown_body = build_email_markdown(signal, docs, new_symbols, generated_at)
+        preview_path = write_email_preview(preview_dir, signal, subject, markdown_body)
+        append_summary_entry(signal, subject, preview_path, markdown_body)
+        print(f"Wrote {preview_path}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Replace live email delivery with markdown previews so reports can be reviewed in the interface instead of being sent. 
- Include actual resolution numbers, operative paragraphs and links in a format optimized for consumption in an email-like markdown preview. 
- Update CI workflow and docs to reflect preview-only behavior and avoid requiring SMTP/Mailgun secrets.

### Description
- Removed SMTP/Mailgun delivery code and related dataclasses and now generate markdown previews from `src/mandate_pipeline/email_report.py` using `build_email_markdown` and `write_email_preview`.
- Embedded resolution metadata and numbered operative paragraphs in the markdown via `format_paragraphs_markdown`, and mark newly discovered resolutions as `(**NEW**)`.
- Changed CLI behavior so the module always writes markdown previews to the preview directory (default `./email-previews`) and appends an inlined markdown summary to the GitHub Actions job summary via `append_summary_entry`.
- Updated the workflow `/.github/workflows/email-signals.yml` to run markdown report generation (removed SMTP/Mailgun envs) and updated `README.md` to document the preview-only behavior and the `SIGNAL_EMAIL_RECIPIENTS` optional usage.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973b15af6c4832ebf39922515f744e5)