### PR TITLE
Keep signal tags inline in the signal browser

### DIFF
--- a/src/mandate_pipeline/templates/static/signals_unified.html
+++ b/src/mandate_pipeline/templates/static/signals_unified.html
@@ -103,8 +103,8 @@
                 <div class="divide-y divide-gray-100">
                     {% for para in doc.signal_paragraphs %}
                     <div class="px-4 py-3 paragraph-item" data-signals="{{ para.signals|join(',') }}">
-                        <p class="text-gray-700 leading-relaxed text-sm flex flex-wrap items-baseline gap-2">
-                            <span class="flex flex-wrap gap-1.5">
+                        <p class="text-gray-700 leading-relaxed text-sm">
+                            <span class="inline-flex flex-wrap gap-1.5 align-baseline mr-2">
                                 {% for signal in para.signals %}
                                 <span class="px-2 py-0.5 rounded text-xs font-medium signal-tag inline-flex items-center justify-center
                                     {% if signal == 'agenda' %}bg-blue-100 text-blue-700
@@ -116,8 +116,8 @@
                                 </span>
                                 {% endfor %}
                             </span>
-                            <span class="font-medium text-gray-700">{{ para.number }}.</span>
-                            <span class="min-w-0">{{ para.text|highlight_signals(para.signals) }}</span>
+                            <span class="font-medium text-gray-700 mr-2">{{ para.number }}.</span>
+                            <span>{{ para.text|highlight_signals(para.signals) }}</span>
                         </p>
                     </div>
                     {% endfor %}


### PR DESCRIPTION
### Motivation
- Paragraph signal tags in the unified Signal Browser were wrapping to a second line so the paragraph number and text appeared on a new line, which made rows look broken and harder to scan.

### Description
- Update the paragraph layout in `src/mandate_pipeline/templates/static/signals_unified.html` to render the signal tags, paragraph number, and paragraph text inline so each item appears on a single line in the browser view.
- Replace the block-level/flex wrapping on the paragraph container with `inline-flex` for the tag group and add small margins (`mr-2`) to keep spacing between tags, number, and text.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bb20077c832ea5008208a65be8fa)