### PR TITLE
Cache missing UNDL metadata lookups

### DIFF
--- a/tests/test_linking.py
+++ b/tests/test_linking.py
@@ -205,6 +205,26 @@ class TestFetchUndlMetadata:
 
         assert result is None
 
+    def test_fetch_symbol_not_found_cached(self, mocker, mock_session):
+        """Cache empty metadata when the symbol is missing from a valid response."""
+        mock_response = mocker.Mock()
+        mock_response.status_code = 200
+        mock_response.text = SAMPLE_MARC_XML
+        mock_response.raise_for_status = mocker.Mock()
+
+        mock_session.get.return_value = mock_response
+        mocker.patch("mandate_pipeline.linking.time.sleep")
+        save_cache = mocker.patch("mandate_pipeline.linking._save_cached_metadata")
+        mocker.patch("mandate_pipeline.linking._get_cached_metadata", return_value=None)
+
+        result = fetch_undl_metadata("A/RES/80/999")
+
+        assert result is not None
+        assert result["draft_symbols"] == []
+        assert result["base_proposal"] is None
+        assert result["not_found"] is True
+        save_cache.assert_called_once()
+
 
 class TestLinkDocumentsWithUndl:
     """Tests for link_documents with UNDL metadata integration."""


### PR DESCRIPTION
### Motivation
- UN Digital Library lookups can be rate-limited and the pipeline observed repeated 429s for symbols with no record, causing redundant network calls for data that never changes. 
- The existing implementation only cached positive results, so "not found" responses were re-queried repeatedly. 
- Allowing the cache location to be configurable helps when running pipelines across environments or centralized cache servers.

### Description
- Added `MANDATE_UNDL_CACHE_DIR` environment variable support and made `CACHE_DIR` use `os.getenv(UNDL_CACHE_ENV, "data/cache/undl")` so the UNDL cache directory is configurable. 
- Persist a lightweight "not found" metadata payload for valid XML responses that do not contain the requested symbol by introducing `_build_empty_metadata` and saving it when parsing succeeds but no matching record is found. 
- Refactored MARC XML parsing into `_extract_undl_metadata` and `_parse_undl_marc_xml_with_status` so callers can distinguish between a successful parse with no record and a parse failure, while preserving the old `_parse_undl_marc_xml` API for backwards compatibility. 
- Added a unit test `test_fetch_symbol_not_found_cached` to `tests/test_linking.py` to assert that missing-symbol responses are cached as empty metadata with a `not_found` flag.

### Testing
- Ran `pytest tests/test_linking.py`; test collection failed with `ModuleNotFoundError: No module named 'requests'`, so the full test suite could not be executed in this environment. 
- The new unit test `test_fetch_symbol_not_found_cached` was added and exercises the caching-path for missing symbols under mocked HTTP responses, but could not be validated end-to-end due to the missing dependency during test collection. 
- Note that the project `.gitignore` contains `data/cache/`, so the cache directory is intentionally not tracked, and a centralized or shared cache should be mounted or pointed to with `MANDATE_UNDL_CACHE_DIR` in CI or deployment to make the cache effective across runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973bf22d404832e8d7407bf5bde56cb)