### PR TITLE
Fix git safe directory warnings in CI pipeline

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -76,6 +76,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
 
       - name: Discover new documents
@@ -132,6 +133,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
 
       - name: Extract document content
@@ -232,6 +234,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
 
       - name: Run signal detection
@@ -348,6 +351,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
 
       - name: Run document linking
@@ -445,6 +449,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
 
       - name: Generate unified signals explorer
@@ -537,6 +542,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
 
       - name: Sync IGov decisions
@@ -606,6 +612,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
 
       - name: Generate IGov signal browser
@@ -646,7 +653,7 @@ jobs:
     name: Build Session
     runs-on: ubuntu-latest
     container: python:3.12-slim
-    if: inputs.stages == 'all' || inputs.stages == 'build-session'
+    if: (inputs.stages == 'all' || inputs.stages == 'build-session') && inputs.session_number != ''
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -654,6 +661,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
 
       - name: Build session


### PR DESCRIPTION
## Summary
This PR adds the `git config --global --add safe.directory` configuration to all workflow jobs that use git operations. This resolves git security warnings that occur when git operations are performed in containers with different ownership contexts.

## Changes
- Added `git config --global --add safe.directory "$GITHUB_WORKSPACE"` to the dependency installation step in all 8 pipeline jobs:
  - discover-documents
  - extract-document-content
  - run-signal-detection
  - run-document-linking
  - generate-unified-signals-explorer
  - sync-igov-decisions
  - generate-igov-signal-browser
  - build-session

- Updated the `build-session` job condition to also check that `session_number` is not empty: `(inputs.stages == 'all' || inputs.stages == 'build-session') && inputs.session_number != ''`

## Details
The `safe.directory` configuration is necessary in containerized environments where the workspace directory may have different ownership than the git process user. This prevents git from refusing to operate on the repository and eliminates security-related warnings in the CI logs.

The additional condition on the `build-session` job ensures the job only runs when a valid session number is provided, preventing unnecessary job execution.