### PR TITLE
Ensure workflows fetch full history and checkout branch before writing

### DIFF
--- a/.github/workflows/discover.yml
+++ b/.github/workflows/discover.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -34,6 +36,9 @@ jobs:
 
       - name: Install dependencies
         run: pip install -e .
+
+      - name: Ensure branch checkout
+        run: git checkout -B "${GITHUB_REF_NAME}"
 
       - name: Discover new documents
         if: github.event.inputs.session_number == ''

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -51,6 +53,9 @@ jobs:
 
       - name: Install dependencies
         run: pip install -e .
+
+      - name: Ensure branch checkout
+        run: git checkout -B "${GITHUB_REF_NAME}"
 
       - name: Generate unified signals explorer
         if: steps.check.outputs.has_changes == 'true'

--- a/.github/workflows/link.yml
+++ b/.github/workflows/link.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 2
+          fetch-depth: 0
 
       - name: Check for detection changes
         id: check
@@ -49,6 +49,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -58,6 +60,9 @@ jobs:
 
       - name: Install dependencies
         run: pip install -e .
+
+      - name: Ensure branch checkout
+        run: git checkout -B "${GITHUB_REF_NAME}"
 
       - name: Run document linking
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -72,12 +72,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
+
+      - name: Ensure branch checkout
+        run: git checkout -B "${GITHUB_REF_NAME}"
 
       - name: Discover new documents
         if: inputs.session_number == ''
@@ -129,12 +134,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
+
+      - name: Ensure branch checkout
+        run: git checkout -B "${GITHUB_REF_NAME}"
 
       - name: Extract document content
         run: |
@@ -230,12 +240,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
+
+      - name: Ensure branch checkout
+        run: git checkout -B "${GITHUB_REF_NAME}"
 
       - name: Run signal detection
         run: |
@@ -347,12 +362,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
+
+      - name: Ensure branch checkout
+        run: git checkout -B "${GITHUB_REF_NAME}"
 
       - name: Run document linking
         run: |
@@ -445,12 +465,17 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Install dependencies
         run: |
           apt-get update && apt-get install -y --no-install-recommends git
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           pip install --cache-dir ${{ env.PIP_CACHE_DIR }} -e .
+
+      - name: Ensure branch checkout
+        run: git checkout -B "${GITHUB_REF_NAME}"
 
       - name: Generate unified signals explorer
         env:


### PR DESCRIPTION
### Motivation
- GitHub Actions runs that update repository files were failing due to shallow checkouts and detached HEAD states, preventing reliable `git diff` checks and pushes. 
- Workflows that commit or push back to the repository need a full history and a local branch to avoid errors during CI-driven updates.

### Description
- Set `fetch-depth: 0` on `actions/checkout@v4` in the workflow files to fetch full git history for accurate diffs and operations. 
- Add an `Ensure branch checkout` step that runs `git checkout -B "${GITHUB_REF_NAME}"` in the discover, link, generate, and pipeline workflows so the runner is on a writable branch. 
- Replace a previous shallow `fetch-depth: 2` usage with `fetch-depth: 0` in the link workflow to keep behavior consistent. 
- Changes were made to `.github/workflows/discover.yml`, `.github/workflows/link.yml`, `.github/workflows/generate.yml`, and `.github/workflows/pipeline.yml` to harden stages that write back to the repo.

### Testing
- No automated tests were run because these are workflow-only changes that affect CI behavior rather than library code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697790bed134832eb00c238df132a27b)