### PR TITLE
Fix generate pipeline failure: populate missing origin field

### DIFF
--- a/src/mandate_pipeline/generation.py
+++ b/src/mandate_pipeline/generation.py
@@ -1570,6 +1570,16 @@ def generate_site(config_dir: Path, data_dir: Path, output_dir: Path) -> None:
     use_undl_metadata = os.getenv("SKIP_UNDL_METADATA", "false").lower() != "true"
     link_documents(documents, use_undl_metadata=use_undl_metadata)
     annotate_linkage(documents)
+
+    # Populate origin for all documents
+    for doc in documents:
+        if doc.get("doc_type") == "resolution":
+            doc["origin"] = derive_resolution_origin(doc)
+        elif doc.get("doc_type") == "proposal":
+            doc["origin"] = derive_origin_from_symbol(doc["symbol"])
+        else:
+            doc["origin"] = "Unknown"
+
     visible_documents = [doc for doc in documents if not doc.get("is_adopted_draft")]
 
     # Create output directories
@@ -1742,6 +1752,16 @@ def generate_site_verbose(
 
     link_documents(documents)
     annotate_linkage(documents)
+
+    # Populate origin for all documents
+    for doc in documents:
+        if doc.get("doc_type") == "resolution":
+            doc["origin"] = derive_resolution_origin(doc)
+        elif doc.get("doc_type") == "proposal":
+            doc["origin"] = derive_origin_from_symbol(doc["symbol"])
+        else:
+            doc["origin"] = "Unknown"
+
     visible_documents = [doc for doc in documents if not doc.get("is_adopted_draft")]
 
     load_duration = time.time() - load_start_time


### PR DESCRIPTION
The generate pipeline was failing with a `jinja2.exceptions.UndefinedError: 'dict object' has no attribute 'origin'` when rendering `signals_unified.html`.

This was caused by the `origin` field not being populated in the document dictionary during the generation process.

This commit modifies `src/mandate_pipeline/generation.py` to:
1.  Populate the `origin` field for all documents in `generate_site` and `generate_site_verbose` after `annotate_linkage` is called.
2.  Uses `derive_resolution_origin` for resolutions and `derive_origin_from_symbol` for proposals.

This ensures that the `origin` attribute is available for templates that rely on it.

---
*PR created automatically by Jules for task [5555623799571512176](https://jules.google.com/task/5555623799571512176) started by @wannli*