### PR TITLE
fix: derive origin for documents in generate_site to prevent template error

### DIFF
--- a/src/mandate_pipeline/generation.py
+++ b/src/mandate_pipeline/generation.py
@@ -1570,6 +1570,12 @@ def generate_site(config_dir: Path, data_dir: Path, output_dir: Path) -> None:
     use_undl_metadata = os.getenv("SKIP_UNDL_METADATA", "false").lower() != "true"
     link_documents(documents, use_undl_metadata=use_undl_metadata)
     annotate_linkage(documents)
+
+    # Derive origin committee for each document
+    for doc in documents:
+        if "origin" not in doc:
+            doc["origin"] = derive_resolution_origin(doc)
+
     visible_documents = [doc for doc in documents if not doc.get("is_adopted_draft")]
 
     # Create output directories
@@ -1742,6 +1748,12 @@ def generate_site_verbose(
 
     link_documents(documents)
     annotate_linkage(documents)
+
+    # Derive origin committee for each document
+    for doc in documents:
+        if "origin" not in doc:
+            doc["origin"] = derive_resolution_origin(doc)
+
     visible_documents = [doc for doc in documents if not doc.get("is_adopted_draft")]
 
     load_duration = time.time() - load_start_time

--- a/src/mandate_pipeline/templates/static/signals_unified.html
+++ b/src/mandate_pipeline/templates/static/signals_unified.html
@@ -57,7 +57,7 @@
             {% for doc in documents %}
             <div class="border border-gray-200 rounded-lg overflow-hidden document-card hover:border-gray-300 transition-colors{% if doc.doc_type == 'proposal' %} border-l-4 border-l-amber-400{% endif %}"
                  data-symbol="{{ doc.symbol }}"
-                 data-source="{{ doc.origin }}"
+                 data-source="{{ doc.origin|default('Unknown', true) }}"
                  data-doctype="{{ doc.doc_type }}"
                  data-signals="{{ doc.signal_summary.keys()|list|join(',') }}"
                  data-un-url="{{ doc.un_url }}">
@@ -83,7 +83,7 @@
                                     {% elif doc.origin == 'C5' %}bg-orange-50 text-orange-700
                                     {% elif doc.origin == 'C6' %}bg-teal-50 text-teal-700
                                     {% else %}bg-gray-100 text-gray-700{% endif %}">
-                                    {{ doc.origin[:2] }}
+                                    {{ (doc.origin|default('?', true))[:2] }}
                                 </span>
                             </div>
                             {% if doc.title %}


### PR DESCRIPTION
The signals_unified.html template accesses doc.origin but this field was
never set when generating from raw PDFs (generate_site / generate_site_verbose).
Documents loaded from data/linked/ already had origin set, masking the bug.

https://claude.ai/code/session_015uTVnKDhs9AyfbzVn3U2ku